### PR TITLE
Minor fixes

### DIFF
--- a/src/algokit/__init__.py
+++ b/src/algokit/__init__.py
@@ -1,53 +1,41 @@
-import logging
+import platform
 import sys
 
 import click
-from click import Context
+
+# this isn't beautiful, but to avoid confusing user errors we need this check before we start importing our own modules
+if sys.version_info < (3, 10, 0):
+    click.echo(
+        click.style(
+            f"Unsupported CPython version: {platform.python_version()} detected.\n"
+            "The minimum version of Python supported is CPython 3.10.\n"
+            "If you need help installing then this is a good starting point: \n"
+            "https://www.python.org/about/gettingstarted/",
+            fg="red",
+        ),
+        err=True,
+    )
+    sys.exit(-1)
 
 from algokit.cli.init import init_command
 from algokit.cli.sandbox import sandbox_group
 from algokit.cli.version import version_command
 
 
-class ConfigurationError(Exception):
-    pass
-
-
-CLICK_CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-
-
 @click.group(
     help="AlgoKit is your one-stop shop to develop applications on the Algorand blockchain.",
     invoke_without_command=True,
-    context_settings=CLICK_CONTEXT_SETTINGS,
+    context_settings={"help_option_names": ["-h", "--help"]},
 )
 @click.option("--version", help="Show current version of AlgoKit cli", is_flag=True)
 @click.pass_context
-def cli(ctx: Context, version: bool):
-    check_python_version()
+def cli(ctx: click.Context, version: bool):
     if version:
         ctx.invoke(version_command)
-        return
-
-    # The help output would normally show when no subcommands have been supplied,
-    # but we override the default behavior through the invoke_without_command so we can show 'algokit --version'
-    if ctx.invoked_subcommand is None:
-        print(ctx.get_help())
-
-
-def check_python_version():
-    installed_python_version = sys.version_info
-    logging.debug(
-        f"Python version "
-        f"{installed_python_version.major}.{installed_python_version.minor}.{installed_python_version.micro} installed"
-    )
-    if installed_python_version < (3, 10, 0):
-        raise ConfigurationError(
-            f"Unsupported CPython version "
-            f"({installed_python_version.major}.{installed_python_version.minor}.{installed_python_version.micro}) "
-            f"detected. The minimum version of Python supported is CPython 3.10.\n\nIf you need help installing then "
-            f"this is a good starting point: https://www.python.org/about/gettingstarted/."
-        )
+    elif ctx.invoked_subcommand is None:
+        # The help output would normally show when no subcommands have been supplied,
+        # but we override the default behavior through the invoke_without_command so we can show 'algokit --version'
+        click.echo(ctx.get_help())
 
 
 cli.add_command(init_command)
@@ -56,8 +44,4 @@ cli.add_command(version_command)
 
 
 if __name__ == "__main__":
-    try:
-        cli()
-    except ConfigurationError as ce:
-        logging.error(f"Configuration error: {str(ce)}")
-        sys.exit(1)
+    cli()

--- a/src/algokit/cli/sandbox.py
+++ b/src/algokit/cli/sandbox.py
@@ -6,7 +6,7 @@ def sandbox_group():
     print("Hello I'm the sandbox command group")
 
 
-@sandbox_group.command()
+@sandbox_group.command("restart")
 def restart_sandbox():
     print("Restarting the sandbox now...")
     # TODO: the thing


### PR DESCRIPTION
- fix missing command name for sandbox restart
- check Python version that alogkit is running under as early as possible, to avoid potentially confusing errors
- minor simplifications