### PR TITLE
Sandbox: fix & test start failure messaging, tweak wording to remove Docker refs

### DIFF
--- a/src/algokit/cli/sandbox.py
+++ b/src/algokit/cli/sandbox.py
@@ -2,8 +2,7 @@ import logging
 
 import click
 from algokit.core import exec
-from algokit.core.conf import get_app_config_dir
-from algokit.core.sandbox import get_docker_compose_yml
+from algokit.core.sandbox import ComposeFileStatus, ComposeSandbox
 
 logger = logging.getLogger(__name__)
 
@@ -29,56 +28,37 @@ def sandbox_group() -> None:
     exec.run(["docker", "version"], bad_return_code_error_message="Docker engine isn't running; please start it.")
 
 
-@sandbox_group.command("start", short_help="Start the AlgoKit sandbox")
+@sandbox_group.command("start", short_help="Start the AlgoKit Sandbox")
 def start_sandbox() -> None:
-    sandbox_dir = get_app_config_dir() / "sandbox"
-    if not sandbox_dir.exists():
-        logger.debug("Sandbox directory does not exist yet; creating it")
-        sandbox_dir.mkdir()
-    sandbox_compose_path = sandbox_dir / "docker-compose.yml"
-    compose_content = get_docker_compose_yml()
-    if not sandbox_compose_path.exists():
+    sandbox = ComposeSandbox()
+    compose_file_status = sandbox.compose_file_status()
+    if compose_file_status is ComposeFileStatus.MISSING:
         logger.debug("Sandbox compose file does not exist yet; writing it out for the first time")
-        sandbox_compose_path.write_text(compose_content)
-    elif sandbox_compose_path.read_text() == compose_content:
+        sandbox.write_compose_file()
+    elif compose_file_status is ComposeFileStatus.UP_TO_DATE:
         logger.debug("Sandbox compose file does not require updating")
     else:
         logger.warning("Sandbox definition is out of date; please run algokit sandbox reset")
-    logger.info("Starting the AlgoKit sandbox now...")
-    exec.run("docker compose up --detach --quiet-pull --wait".split(), cwd=sandbox_dir, stdout_log_level=logging.INFO)
-    logger.info("Started; execute `algokit sandbox status` to check the status.")
+    sandbox.up()
 
 
-@sandbox_group.command("reset", short_help="Reset the AlgoKit sandbox")
+@sandbox_group.command("reset", short_help="Reset the AlgoKit Sandbox")
 @click.option(
-    "--pull/--no-pull",
+    "--update/--no-update",
     default=True,
-    expose_value=True,
-    help="Enable or disable pulling latest images from DockerHub",
+    help="Enable or disable updating to the latest available Sandbox version",
 )
-@click.pass_context
-def reset_sandbox(ctx: click.Context, *, pull: bool) -> None:
-    sandbox_dir = get_app_config_dir() / "sandbox"
-    sandbox_compose_path = sandbox_dir / "docker-compose.yml"
-    if not sandbox_compose_path.exists():
+def reset_sandbox(update: bool) -> None:  # noqa: FBT001
+    sandbox = ComposeSandbox()
+    compose_file_status = sandbox.compose_file_status()
+    if compose_file_status is ComposeFileStatus.MISSING:
         logger.debug("Existing Sandbox not found; creating from scratch...")
-        ctx.invoke(start_sandbox)
+        sandbox.write_compose_file()
     else:
-        logger.info("Deleting any existing Sandbox...")
-        exec.run("docker compose down".split(), cwd=sandbox_dir, stdout_log_level=logging.DEBUG)
-        compose_content = get_docker_compose_yml()
-        if sandbox_compose_path.read_text() != compose_content:
+        sandbox.down()
+        if compose_file_status is not ComposeFileStatus.UP_TO_DATE:
             logger.info("Sandbox definition is out of date; updating it to latest")
-            sandbox_compose_path.write_text(compose_content)
-        if pull:
-            logger.info("Looking for latest Sandbox images from DockerHub...")
-            exec.run(
-                "docker compose pull --ignore-pull-failures --quiet".split(),
-                cwd=sandbox_dir,
-                stdout_log_level=logging.INFO,
-            )
-        logger.info("Starting the AlgoKit sandbox now...")
-        exec.run(
-            "docker compose up --detach --quiet-pull --wait".split(), cwd=sandbox_dir, stdout_log_level=logging.INFO
-        )
-        logger.info("Started; execute `algokit sandbox status` to check the status.")
+            sandbox.write_compose_file()
+        if update:
+            sandbox.pull()
+    sandbox.up()

--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -1,3 +1,74 @@
+import enum
+import logging
+from pathlib import Path
+
+from algokit.core.conf import get_app_config_dir
+from algokit.core.exec import RunResult, run
+
+logger = logging.getLogger(__name__)
+
+
+class ComposeFileStatus(enum.Enum):
+    MISSING = enum.auto()
+    UP_TO_DATE = enum.auto()
+    OUT_OF_DATE = enum.auto()
+
+
+class ComposeSandbox:
+    def __init__(self) -> None:
+        self.directory = get_app_config_dir() / "sandbox"
+        if not self.directory.exists():
+            logger.debug("Sandbox directory does not exist yet; creating it")
+            self.directory.mkdir()
+        self._latest_yaml = get_docker_compose_yml()
+
+    @property
+    def compose_file_path(self) -> Path:
+        return self.directory / "docker-compose.yml"
+
+    def compose_file_status(self) -> ComposeFileStatus:
+        try:
+            content = self.compose_file_path.read_text()
+        except FileNotFoundError:
+            return ComposeFileStatus.MISSING
+        else:
+            if content == self._latest_yaml:
+                return ComposeFileStatus.UP_TO_DATE
+            else:
+                return ComposeFileStatus.OUT_OF_DATE
+
+    def write_compose_file(self) -> None:
+        self.compose_file_path.write_text(self._latest_yaml)
+
+    def _run_compose_command(
+        self,
+        compose_args: str,
+        stdout_log_level: int = logging.INFO,
+        bad_return_code_error_message: str | None = None,
+    ) -> RunResult:
+        return run(
+            ["docker", "compose", *compose_args.split()],
+            cwd=self.directory,
+            stdout_log_level=stdout_log_level,
+            bad_return_code_error_message=bad_return_code_error_message,
+        )
+
+    def up(self) -> None:
+        logger.info("Starting the AlgoKit sandbox now...")
+        self._run_compose_command(
+            "up --detach --quiet-pull --wait", bad_return_code_error_message="Failed to start Sandbox"
+        )
+        logger.info("Started; execute `algokit sandbox status` to check the status.")
+
+    def down(self) -> None:
+        logger.info("Deleting any existing Sandbox...")
+        self._run_compose_command("down", stdout_log_level=logging.DEBUG)
+
+    def pull(self) -> None:
+        logger.info("Looking for latest Sandbox images from DockerHub...")
+        self._run_compose_command("pull --ignore-pull-failures --quiet")
+
+
 def get_docker_compose_yml(
     name: str = "algokit",
     algod_port: int = 4001,
@@ -6,6 +77,7 @@ def get_docker_compose_yml(
     indexer_port: int = 8980,
 ) -> str:
     return f"""version: '3'
+name: "{name}_sandbox"
 
 services:
   algod:

--- a/tests/sandbox/test_sandbox_reset.py
+++ b/tests/sandbox/test_sandbox_reset.py
@@ -55,7 +55,7 @@ def test_sandbox_reset_with_existing_sandbox_with_up_to_date_config_no_pull(app_
     (app_dir_mock.app_config_dir / "sandbox").mkdir()
     (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").write_text(get_docker_compose_yml())
 
-    result = invoke("sandbox reset --no-pull")
+    result = invoke("sandbox reset --no-update")
 
     assert result.exit_code == 0
     verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))

--- a/tests/sandbox/test_sandbox_reset.test_sandbox_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
+++ b/tests/sandbox/test_sandbox_reset.test_sandbox_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
@@ -22,6 +22,7 @@ Started; execute `algokit sandbox status` to check the status.
 {app_config}/sandbox/docker-compose.yml:
 ----
 version: '3'
+name: "algokit_sandbox"
 
 services:
   algod:

--- a/tests/sandbox/test_sandbox_reset.test_sandbox_reset_without_existing_sandbox.approved.txt
+++ b/tests/sandbox/test_sandbox_reset.test_sandbox_reset_without_existing_sandbox.approved.txt
@@ -4,9 +4,8 @@ DEBUG: docker: STDERR
 DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
-DEBUG: Existing Sandbox not found; creating from scratch...
 DEBUG: Sandbox directory does not exist yet; creating it
-DEBUG: Sandbox compose file does not exist yet; writing it out for the first time
+DEBUG: Existing Sandbox not found; creating from scratch...
 Starting the AlgoKit sandbox now...
 DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in '{app_config}/sandbox'
 docker: STDOUT
@@ -16,6 +15,7 @@ Started; execute `algokit sandbox status` to check the status.
 {app_config}/sandbox/docker-compose.yml:
 ----
 version: '3'
+name: "algokit_sandbox"
 
 services:
   algod:

--- a/tests/sandbox/test_sandbox_start.py
+++ b/tests/sandbox/test_sandbox_start.py
@@ -25,6 +25,15 @@ def test_sandbox_start(app_dir_mock: AppDirs, exec_mock: ExecMock):
     )
 
 
+def test_sandbox_start_failure(app_dir_mock: AppDirs, exec_mock: ExecMock):
+    exec_mock.should_bad_exit_on("docker compose up")
+
+    result = invoke("sandbox start")
+
+    assert result.exit_code == 1
+    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+
+
 def test_sandbox_start_up_to_date_definition(app_dir_mock: AppDirs, exec_mock: ExecMock):
     (app_dir_mock.app_config_dir / "sandbox").mkdir()
     (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").write_text(get_docker_compose_yml())

--- a/tests/sandbox/test_sandbox_start.test_sandbox_start.approved.txt
+++ b/tests/sandbox/test_sandbox_start.test_sandbox_start.approved.txt
@@ -15,6 +15,7 @@ Started; execute `algokit sandbox status` to check the status.
 {app_config}/sandbox/docker-compose.yml:
 ----
 version: '3'
+name: "algokit_sandbox"
 
 services:
   algod:

--- a/tests/sandbox/test_sandbox_start.test_sandbox_start_failure.approved.txt
+++ b/tests/sandbox/test_sandbox_start.test_sandbox_start_failure.approved.txt
@@ -1,0 +1,13 @@
+DEBUG: Running 'docker compose version' in '{current_working_directory}'
+DEBUG: docker: STDOUT
+DEBUG: docker: STDERR
+DEBUG: Running 'docker version' in '{current_working_directory}'
+DEBUG: docker: STDOUT
+DEBUG: docker: STDERR
+DEBUG: Sandbox directory does not exist yet; creating it
+DEBUG: Sandbox compose file does not exist yet; writing it out for the first time
+Starting the AlgoKit sandbox now...
+DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in '{app_config}/sandbox'
+docker: STDOUT
+docker: STDERR
+Error: Failed to start Sandbox

--- a/tests/utils/app_dir_mock.py
+++ b/tests/utils/app_dir_mock.py
@@ -13,7 +13,7 @@ class AppDirs:
 def tmp_app_dir(mocker: MockerFixture, tmp_path: Path) -> AppDirs:
     app_config_dir = tmp_path / "config"
     app_config_dir.mkdir()
-    mocker.patch("algokit.cli.sandbox.get_app_config_dir").return_value = app_config_dir
+    mocker.patch("algokit.core.sandbox.get_app_config_dir").return_value = app_config_dir
 
     app_state_dir = tmp_path / "state"
     app_state_dir.mkdir()


### PR DESCRIPTION
- Reduce usage of Docker nomenclature to make help/flags easier to understand
- Don't print success message if up fails & add test for this
- Extract common sandbox/docker compose logic