### PR TITLE
split build&test from linting etc

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -36,17 +36,6 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 
-      - name: Check code style with Black
-        uses: psf/black@stable
-
-      - name: Lint with Ruff
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          poetry run ruff .
-
-      - name: mypy
-        run: poetry run mypy
-
       - name: Test with pytest
         run: poetry run pytest
 

--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -1,0 +1,34 @@
+name: Check Python Code
+
+on:
+  workflow_call:
+
+jobs:
+  check-python:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Check code style with Black
+        uses: psf/black@stable
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Lint with Ruff
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          poetry run ruff .
+
+      - name: mypy
+        run: poetry run mypy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,14 @@ name: AlgoKit CI
 on: [pull_request]
       
 jobs:
+  ci-check:
+    name: Check (CI)
+    uses: ./.github/workflows/check-python.yaml
+
   ci-build:
     name: Build (CI)
+    # don't run build & test until basic checks have passed
+    needs: ci-check
     uses: ./.github/workflows/build-python.yaml
     with:
       shouldPublish: false


### PR DESCRIPTION
Speeds up build for quicker feedback - we don't need ruff/black/mypy etc to run per platform