### PR TITLE
Templates with commit hash

### DIFF
--- a/src/algokit/cli/init.py
+++ b/src/algokit/cli/init.py
@@ -110,8 +110,19 @@ def init_command(
 
     logger.debug(f"Attempting to initialise project in {project_path} from template {template_url}")
 
+    vcs_ref = None
+    if "@" in str(template_url):
+        split_by_at = template_url.split("@")
+        template_url = split_by_at[0]
+        vcs_ref = split_by_at[1]
+
     copier_worker = copier.run_copy(
-        template_url, project_path, data=answers_dict, defaults=defaults or False, quiet=True
+        template_url,
+        project_path,
+        data=answers_dict,
+        defaults=defaults or False,
+        quiet=True,
+        vcs_ref=vcs_ref,
     )
 
     expanded_template_url = copier_worker.template.url_expanded
@@ -125,7 +136,10 @@ def init_command(
     if re.search("https?://", expanded_template_url):
         # if the URL looks like an HTTP URL (should be the case for blessed templates), be helpful
         # and print it out so the user can (depending on terminal) click it to open in browser
-        logger.info(f"Your selected template comes from:\n➡️  {expanded_template_url.removesuffix('.git')}")
+        logger.info(
+            f"Your selected template comes from:\n➡️  {expanded_template_url.removesuffix('.git')}"
+            + (f"@{vcs_ref}" if vcs_ref else "")
+        )
 
 
 def _fail_and_bail() -> Never:

--- a/tests/init/test_init.py
+++ b/tests/init/test_init.py
@@ -37,6 +37,7 @@ def set_blessed_templates(mocker: MockerFixture):
     mocker.patch("algokit.cli.init._get_blessed_templates").return_value = {
         "simple": "gh:robdmoore/copier-helloworld",
         "beaker": "gh:wilsonwaters/copier-testing-template",
+        "beaker_with_version": "gh:wilsonwaters/copier-testing-template@96fc7fd766fac607cdf5d69ee6e85ade04dddd47",
     }
 
 
@@ -368,6 +369,28 @@ def test_init_with_official_template_name(tmp_path_factory: TempPathFactory, moc
 
     result = invoke(
         "init --name myapp --no-git --template beaker --defaults -a run_poetry_install False",
+        cwd=cwd,
+    )
+
+    assert result.exit_code == 0
+    paths = {p.relative_to(cwd) for p in cwd.rglob("*")}
+    assert paths.issuperset(
+        {
+            Path("myapp"),
+            Path("myapp") / "README.md",
+            Path("myapp") / "smart_contracts",
+        }
+    )
+    verify(result.output, scrubber=make_output_scrubber())
+
+
+def test_init_with_official_template_name_and_hash(
+    tmp_path_factory: TempPathFactory, mock_questionary_input: PipeInput
+):
+    cwd = tmp_path_factory.mktemp("cwd")
+
+    result = invoke(
+        "init --name myapp --no-git --template beaker_with_version --defaults -a run_poetry_install False",
         cwd=cwd,
     )
 

--- a/tests/init/test_init.test_init_help.approved.txt
+++ b/tests/init/test_init.test_init_help.approved.txt
@@ -3,15 +3,18 @@ Usage: algokit init [OPTIONS]
   Initializes a new project from a template.
 
 Options:
-  --name TEXT                 Name of the directory / repository to create.
-  --template [simple|beaker]  Name of an official template to use.
-  --template-url URL          URL to a git repo with a custom project template.
-  --accept-template-url       Accept the specified template URL, acknowledging
-                              the security implications of an unofficial
-                              template.
-  --git / --no-git            Initialise git repository in directory after
-                              creation.
-  --defaults                  Automatically choose default answers without
-                              asking when creating this template.
-  -a, --answer <key> <value>  Answers key/value pairs to pass to the template.
-  -h, --help                  Show this message and exit.
+  --name TEXT                     Name of the directory / repository to create.
+  --template [simple|beaker|beaker_with_version]
+                                  Name of an official template to use.
+  --template-url URL              URL to a git repo with a custom project
+                                  template.
+  --accept-template-url           Accept the specified template URL,
+                                  acknowledging the security implications of an
+                                  unofficial template.
+  --git / --no-git                Initialise git repository in directory after
+                                  creation.
+  --defaults                      Automatically choose default answers without
+                                  asking when creating this template.
+  -a, --answer <key> <value>      Answers key/value pairs to pass to the
+                                  template.
+  -h, --help                      Show this message and exit.

--- a/tests/init/test_init.test_init_with_official_template_name_and_hash.approved.txt
+++ b/tests/init/test_init.test_init_with_official_template_name_and_hash.approved.txt
@@ -1,0 +1,5 @@
+DEBUG: Attempting to initialise project in {current_working_directory}/myapp from template gh:wilsonwaters/copier-testing-template@96fc7fd766fac607cdf5d69ee6e85ade04dddd47
+DEBUG: Project initialisation complete, final clone URL = https://github.com/wilsonwaters/copier-testing-template.git
+🙌 Project initialized! For next steps, consult the documentation of your selected template 🧐
+Your selected template comes from:
+➡️  https://github.com/wilsonwaters/copier-testing-template@96fc7fd766fac607cdf5d69ee6e85ade04dddd47


### PR DESCRIPTION
feat(init): Implemented ability to specify a commit hash so you can anchor templates from semi-trusted sources to a known good version