### PR TITLE
Fix feature branch release

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -17,7 +17,7 @@ jobs:
   build-python:
     strategy:
       matrix:
-        # os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        #os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         # Mac and Windows chew through build minutes - waiting until repo is public to enable
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.10"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "algokit"
-version = "0.11.2-beta.1"
+version = "0.1.0"
 description = "Algorand development kit command line interface"
 authors = ["Algorand Foundation <contact@algorand.foundation>"]
 license = "MIT"


### PR DESCRIPTION
fix: use last tag when updating the GitHub release, adding verbose logs and force patch only update for feature branches