### PR TITLE
set initial release version to 0.0.0, which will generate 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "algokit"
-version = "0.1.0"
+version = "0.0.0"
 description = "Algorand development kit command line interface"
 authors = ["Algorand Foundation <contact@algorand.foundation>"]
 license = "MIT"


### PR DESCRIPTION
python semantic release is currently complaining about v0.1.0 not being acceptable. I believe this will fix it

https://github.com/algorandfoundation/algokit-cli/actions/runs/3869831025/jobs/6596273203