### PR TITLE
pass through sys.stdin when executing goal command in case it wants input

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -31,7 +31,7 @@
     - [NETWORK](#network)
   - [goal](#goal)
     - [Options](#options-4)
-    - [--console, --no-console](#--console---no-console)
+    - [--console](#--console)
     - [Arguments](#arguments-2)
     - [GOAL_ARGS](#goal_args)
   - [init](#init)
@@ -233,7 +233,7 @@ algokit goal [OPTIONS] [GOAL_ARGS]...
 ### Options
 
 
-### --console, --no-console
+### --console
 Open a Bash console so you can execute multiple goal commands and/or interact with a filesystem.
 
 ### Arguments

--- a/src/algokit/core/proc.py
+++ b/src/algokit/core/proc.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
 import subprocess
+import sys
 from pathlib import Path
 from subprocess import Popen
 from subprocess import run as subprocess_run
@@ -27,6 +28,7 @@ def run(
     bad_return_code_error_message: str | None = None,
     prefix_process: bool = True,
     stdout_log_level: int = logging.DEBUG,
+    pass_stdin: bool = False,
 ) -> RunResult:
     """Wraps subprocess.Popen() similarly to subprocess.run() but adds: logging and streaming (unicode) I/O capture
 
@@ -41,6 +43,7 @@ def run(
         command,
         stdout=subprocess.PIPE,  # capture stdout
         stderr=subprocess.STDOUT,  # redirect stderr to stdout, so they're interleaved in the correct ordering
+        stdin=sys.stdin if pass_stdin else None,
         text=True,  # make all I/O in unicode/text
         cwd=cwd,
         env=env,

--- a/tests/goal/test_goal.test_goal_complex_args.approved.txt
+++ b/tests/goal/test_goal.test_goal_complex_args.approved.txt
@@ -1,6 +1,6 @@
 DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
-DEBUG: Running 'docker exec algokit_algod goal account export -a RKTAZY2ZLKUJBHDVVA3KKHEDK7PRVGIGOZAUUIZBNK2OEP6KQGEXKKUYUY' in '{current_working_directory}'
+DEBUG: Running 'docker exec --interactive --workdir /root algokit_algod goal account export -a RKTAZY2ZLKUJBHDVVA3KKHEDK7PRVGIGOZAUUIZBNK2OEP6KQGEXKKUYUY' in '{current_working_directory}'
  STDOUT
  STDERR

--- a/tests/goal/test_goal.test_goal_help.approved.txt
+++ b/tests/goal/test_goal.test_goal_help.approved.txt
@@ -1,6 +1,6 @@
 Usage: algokit goal [OPTIONS] [GOAL_ARGS]...
 
 Options:
-  --console / --no-console  Open a Bash console so you can execute multiple goal
-                            commands and/or interact with a filesystem.
-  -h, --help                Show this message and exit.
+  --console   Open a Bash console so you can execute multiple goal commands
+              and/or interact with a filesystem.
+  -h, --help  Show this message and exit.

--- a/tests/goal/test_goal.test_goal_no_args.approved.txt
+++ b/tests/goal/test_goal.test_goal_no_args.approved.txt
@@ -1,6 +1,6 @@
 DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
-DEBUG: Running 'docker exec algokit_algod goal' in '{current_working_directory}'
+DEBUG: Running 'docker exec --interactive --workdir /root algokit_algod goal' in '{current_working_directory}'
  STDOUT
  STDERR

--- a/tests/goal/test_goal.test_goal_simple_args.approved.txt
+++ b/tests/goal/test_goal.test_goal_simple_args.approved.txt
@@ -1,6 +1,6 @@
 DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
-DEBUG: Running 'docker exec algokit_algod goal account list' in '{current_working_directory}'
+DEBUG: Running 'docker exec --interactive --workdir /root algokit_algod goal account list' in '{current_working_directory}'
  STDOUT
  STDERR


### PR DESCRIPTION
Fixes #102 

additionally: 
fix: warn rather than ignore extra arguments passed to goal --console

fix: remove unnecessary --no-console flag for goal