### PR TITLE
build: explicitly handle stderr output during chocolatey installation

### DIFF
--- a/scripts/chocolatey/algokit/algokit.nuspec
+++ b/scripts/chocolatey/algokit/algokit.nuspec
@@ -23,6 +23,7 @@
     ]]></description>
     <dependencies>
       <dependency id="python3" version="3.10" />
+      <dependency id="git" />
     </dependencies>
   </metadata>
   <files>

--- a/scripts/chocolatey/algokit/tools/chocolateyinstall.ps1
+++ b/scripts/chocolatey/algokit/tools/chocolateyinstall.ps1
@@ -13,9 +13,17 @@ else {
 Update-SessionEnvironment
 
 # ensure pipx is installed
-python -m pip --disable-pip-version-check install --user pipx *>&1
+python -m pip install --disable-pip-version-check --no-warn-script-location --user pipx
 if ($LASTEXITCODE -ne 0) {
   Throw "Error installing pipx"
+}
+&{
+  # pipx outputs to stderr if path is already configured, so ignore that error
+  $ErrorActionPreference = 'Continue'
+  python -m pipx ensurepath
+  if ($LASTEXITCODE -ne 0) {
+    Throw "Error configuring pipx path"
+  }
 }
 
 # work out the wheel name and make sure there wasn't a packaging error
@@ -24,24 +32,37 @@ if ($wheelFileName.count -ne 1) {
   Throw "Packaging error. nupkg contained $($wheelFile.count) wheel files"
 }
 
-# For some reason pipx outputs normal messages to stderr, which causes choco to complain.
-# So when calling pipx redirect stderr to stdout and rely on return value for errors
-
 # determine if the package is already installed. In which case, uninstall it first
 # Note - pipx upgrade does not work with local files
-$pipxListOutput = python -m pipx list *>&1
-if ($LASTEXITCODE -ne 0) {
-  Throw "Error searching for existing packages"
-}
-if ($pipxListOutput -match "$env:ChocolateyPackageName.*") {
-  python -m pipx uninstall $env:ChocolateyPackageName *>&1
+$pipxListOutput = &{
+  # pipx outputs to stderr if there are no packages, so ignore that error
+  $ErrorActionPreference = 'Continue'
+  python -m pipx list
   if ($LASTEXITCODE -ne 0) {
-    Throw "Error removing existing version"
+    Throw "Error searching for existing packages"
+  }
+}
+
+# uninstall existing package if present
+if ($pipxListOutput -match "$env:ChocolateyPackageName.*") {
+  &{
+    #pipx outputs to stderr as part of normal execution, so ignore stderr
+    $ErrorActionPreference = 'Continue'
+    python -m pipx uninstall $env:ChocolateyPackageName
+    if ($LASTEXITCODE -ne 0) {
+      Throw "Error removing existing version"
+    }
   }
 }
 
 # install the bundled wheel file.
-python -m pipx install $wheelFileName[0].FullName *>&1
-if ($LASTEXITCODE -ne 0) {
-  Throw "Error installing $($wheelFileName[0].FullName)"
+&{
+  #pipx outputs to stderr as part of normal execution, so ignore stderr
+  $ErrorActionPreference = 'Continue'
+  python -m pipx install $wheelFileName[0].FullName
+  if ($LASTEXITCODE -ne 0) {
+    Throw "Error installing $($wheelFileName[0].FullName)"
+  }
 }
+
+

--- a/scripts/chocolatey/algokit/tools/chocolateyuninstall.ps1
+++ b/scripts/chocolatey/algokit/tools/chocolateyuninstall.ps1
@@ -1,21 +1,22 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 # ensure pipx is installed. Just in case someone has removed it manually
-python -m pip --disable-pip-version-check install --user pipx *>&1
+python -m pip install --disable-pip-version-check --no-warn-script-location --user pipx
 if ($LASTEXITCODE -ne 0) {
   Throw "Error configuring pipx for uninstalling"
 }
 
-# For some reason pipx outputs normal messages to stderr, which causes choco to complain.
-# So when calling pipx redirect stderr to stdout and rely on return value for errors
-
 # zap it
-python -m pipx uninstall $env:ChocolateyPackageName *>&1
-if ($LASTEXITCODE -ne 0) {
-  if ($cmdOutput -match "Nothing to uninstall" ) {
-    Write-Output "$($env:ChocolateyPackageName) already uninstalled by pipx. Ignoring"
-  }
-  else {
-    Throw "Error running pipx uninstall $($env:ChocolateyPackageName)"
+&{
+  #pipx outputs to stderr as part of normal execution, so ignore stderr
+  $ErrorActionPreference = 'Continue'
+  python -m pipx uninstall $env:ChocolateyPackageName
+  if ($LASTEXITCODE -ne 0) {
+    if ($cmdOutput -match "Nothing to uninstall" ) {
+      Write-Output "$($env:ChocolateyPackageName) already uninstalled by pipx. Ignoring"
+    }
+    else {
+      Throw "Error running pipx uninstall $($env:ChocolateyPackageName)"
+    }
   }
 }


### PR DESCRIPTION
make git an explicit dependency so 0.1.0 package will work after install