### PR TITLE
feat: add a command to see logs from localnet docker containers

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -48,8 +48,12 @@
   - [localnet](#localnet)
     - [console](#console)
     - [explore](#explore-1)
-    - [reset](#reset)
+    - [logs](#logs)
     - [Options](#options-6)
+    - [--follow, -f](#--follow--f)
+    - [--tail ](#--tail-)
+    - [reset](#reset)
+    - [Options](#options-7)
     - [--update, --no-update](#--update---no-update)
     - [start](#start)
     - [status](#status)
@@ -312,6 +316,30 @@ Explore the AlgoKit LocalNet using Dappflow
 ```shell
 algokit localnet explore [OPTIONS]
 ```
+
+### logs
+
+See the output of the Docker containers
+
+```shell
+algokit localnet logs [OPTIONS]
+```
+
+### Options
+
+
+### --follow, -f
+Follow log output.
+
+
+### --tail <tail>
+Number of lines to show from the end of the logs for each container.
+
+
+* **Default**
+
+    `all`
+
 
 ### reset
 

--- a/src/algokit/cli/localnet.py
+++ b/src/algokit/cli/localnet.py
@@ -155,3 +155,25 @@ def localnet_console(context: click.Context) -> None:
 @click.pass_context
 def localnet_explore(context: click.Context) -> None:
     context.invoke(explore_command)
+
+
+@localnet_group.command(
+    "logs",
+    short_help="See the output of the Docker containers",
+)
+@click.option(
+    "--follow/-f",
+    is_flag=True,
+    help="Follow log output.",
+    default=False,
+)
+@click.option(
+    "--tail",
+    default="all",
+    help="Number of lines to show from the end of the logs for each container.",
+    show_default=True,
+)
+@click.pass_context
+def localnet_logs(ctx: click.Context, *, follow: bool, tail: str) -> None:
+    sandbox = ComposeSandbox()
+    sandbox.logs(follow=follow, no_color=ctx.color is False, tail=tail)

--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import httpx
 
 from algokit.core.conf import get_app_config_dir
-from algokit.core.proc import RunResult, run
+from algokit.core.proc import RunResult, run, run_interactive
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,20 @@ class ComposeSandbox:
     def pull(self) -> None:
         logger.info("Looking for latest Sandbox images from DockerHub...")
         self._run_compose_command("pull --ignore-pull-failures --quiet")
+
+    def logs(self, *, follow: bool = False, no_color: bool = False, tail: str | None = None) -> None:
+        compose_args = ["logs"]
+        if follow:
+            compose_args += ["--follow"]
+        if no_color:
+            compose_args += ["--no-color"]
+        if tail is not None:
+            compose_args += ["--tail", tail]
+        run_interactive(
+            ["docker", "compose", *compose_args],
+            cwd=self.directory,
+            bad_return_code_error_message="Failed to get logs, are the containers running?",
+        )
 
     def ps(self) -> list[dict[str, Any]]:
         run_results = self._run_compose_command("ps --format json", stdout_log_level=logging.DEBUG)

--- a/tests/localnet/test_localnet.test_localnet_help.approved.txt
+++ b/tests/localnet/test_localnet.test_localnet_help.approved.txt
@@ -8,6 +8,7 @@ Commands:
            console so you can execute multiple goal commands and/or interact
            with a filesystem.
   explore  Explore the AlgoKit LocalNet using Dappflow
+  logs     See the output of the Docker containers
   reset    Reset the AlgoKit LocalNet.
   start    Start the AlgoKit LocalNet.
   status   Check the status of the AlgoKit LocalNet.


### PR DESCRIPTION
note, no tests - it's just running a simple command. not much of value to test here without actually passing through to docker compose for real