### PR TITLE
Add Gitpod check for localnet explore

### DIFF
--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -37,7 +37,7 @@ NETWORKS: dict[str, NetworkConfiguration] = {
         "indexer_port": 443 if GITPOD_URL else DEFAULT_INDEXER_PORT,
         "indexer_token": DEFAULT_ALGOD_TOKEN,
         "kmd_token": DEFAULT_ALGOD_TOKEN,
-        "kmd_port": 43 if GITPOD_URL else DEFAULT_ALGOD_PORT + 1,
+        "kmd_port": 443 if GITPOD_URL else DEFAULT_ALGOD_PORT + 1,
         "kmd_url": GITPOD_URL.replace("https://", "https://4002-") if GITPOD_URL else DEFAULT_ALGOD_SERVER,
     },  # TODO: query these instead of using constants
     "testnet": {

--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -22,6 +22,10 @@ class NetworkConfiguration(NetworkConfigurationRequired, total=False):
     indexer_port: int
     indexer_token: str
 
+    kmd_token: str
+    kmd_url: str
+    kmd_port: int
+
 
 GITPOD_URL = os.environ.get("GITPOD_WORKSPACE_URL")
 NETWORKS: dict[str, NetworkConfiguration] = {
@@ -32,6 +36,9 @@ NETWORKS: dict[str, NetworkConfiguration] = {
         "algod_token": DEFAULT_ALGOD_TOKEN,
         "indexer_port": 443 if GITPOD_URL else DEFAULT_INDEXER_PORT,
         "indexer_token": DEFAULT_ALGOD_TOKEN,
+        "kmd_token": DEFAULT_ALGOD_TOKEN,
+        "kmd_port": 43 if GITPOD_URL else DEFAULT_ALGOD_PORT + 1,
+        "kmd_url": GITPOD_URL.replace("https://", "https://4002-") if GITPOD_URL else DEFAULT_ALGOD_SERVER,
     },  # TODO: query these instead of using constants
     "testnet": {
         "algod_url": "https://testnet-api.algonode.cloud",

--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import TypedDict
 from urllib.parse import urlencode
 
@@ -22,13 +23,14 @@ class NetworkConfiguration(NetworkConfigurationRequired, total=False):
     indexer_token: str
 
 
+GITPOD_URL = os.environ.get("GITPOD_WORKSPACE_URL")
 NETWORKS: dict[str, NetworkConfiguration] = {
     "localnet": {
-        "algod_url": DEFAULT_ALGOD_SERVER,
-        "indexer_url": DEFAULT_ALGOD_SERVER,
-        "algod_port": DEFAULT_ALGOD_PORT,
+        "algod_url": GITPOD_URL.replace("https://", "https://4001-") if GITPOD_URL else DEFAULT_ALGOD_SERVER,
+        "indexer_url": GITPOD_URL.replace("https://", "https://8980-") if GITPOD_URL else DEFAULT_ALGOD_SERVER,
+        "algod_port": 443 if GITPOD_URL else DEFAULT_ALGOD_PORT,
         "algod_token": DEFAULT_ALGOD_TOKEN,
-        "indexer_port": DEFAULT_INDEXER_PORT,
+        "indexer_port": 443 if GITPOD_URL else DEFAULT_INDEXER_PORT,
         "indexer_token": DEFAULT_ALGOD_TOKEN,
     },  # TODO: query these instead of using constants
     "testnet": {

--- a/tests/explore/test_explore.test_explore.localnet.approved.txt
+++ b/tests/explore/test_explore.test_explore.localnet.approved.txt
@@ -2,4 +2,4 @@ Opening localnet in https://app.dappflow.org using default browser
 ----
 launch args:
 ----
-call('https://app.dappflow.org/setup-config?algod_url=http%3A%2F%2Flocalhost&indexer_url=http%3A%2F%2Flocalhost&algod_port=4001&algod_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&indexer_port=8980&indexer_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+call('https://app.dappflow.org/setup-config?algod_url=http%3A%2F%2Flocalhost&indexer_url=http%3A%2F%2Flocalhost&algod_port=4001&algod_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&indexer_port=8980&indexer_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&kmd_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&kmd_port=4002&kmd_url=http%3A%2F%2Flocalhost')


### PR DESCRIPTION
If a user is running algokit in gitpod (which we use in bootcamps), running `algokit localnet explore` will fail because dappflow won't be able to connect to `localhost`. This is a minor change that checks whether algokit is running in gitpod and modifies the localnet connection information accordingly. 

End result is `algokit localnet explore` working the same on local machine and on gitpod