### PR TITLE
docs: fixing header in recently merged adr to reflect status and deciders

### DIFF
--- a/docs/architecture-decisions/2023-06-06_frontend-templates.md
+++ b/docs/architecture-decisions/2023-06-06_frontend-templates.md
@@ -1,10 +1,10 @@
 # Frontend Templates
 
-- **Status**: Draft (rev 3)
+- **Status**: Approved
 - **Owner:** Altynbek Orumbayev
-- **Deciders**: TBD
+- **Deciders**: Rob Moore, Daniel McGregor, Adam Chidlow
 - **Date created**: 2023-06-06
-- **Date decided:** TBD
+- **Date decided:** 2023-06-09
 - **Date updated**: 2023-06-08
 
 ## Context


### PR DESCRIPTION
## Proposed Changes

  - fixing header to include deciders (participants of pr review) and status