### PR TITLE
Update docker version command

### DIFF
--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -284,4 +284,4 @@ def fetch_indexer_status_data(service_info: dict[str, Any]) -> dict[str, Any]:
         return {"Status": "Error"}
 
 
-DOCKER_COMPOSE_VERSION_COMMAND = ["docker", "compose", "version", "--format", "json"]
+DOCKER_COMPOSE_VERSION_COMMAND = ["docker", "--version"]


### PR DESCRIPTION
When using a custom build of docker, `docker compose version` will only return the commit hash and not the release version.

```
$ docker compose version
Docker Compose version dde0213

$ docker compose version --format json
{"version":"dde0213"}
```

For the version parsing to work, `docker --version` must be used:

```
$ docker --version
Docker version 23.0.3, build 3e7cbfd
```