### PR TITLE
refactor: performance improvements for vanity; swifter termination handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2855,13 +2855,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.3"
+version = "2.0.6"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
-    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
+    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
+    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
 ]
 
 [package.extras]

--- a/src/algokit/cli/tasks/vanity_address.py
+++ b/src/algokit/cli/tasks/vanity_address.py
@@ -105,7 +105,11 @@ def vanity_address(  # noqa: PLR0913
     match = MatchType(match)  # Force cast since click does not yet support enums as types
     _validate_inputs(keyword, output, alias, output_file_path)
 
-    vanity_account = generate_vanity_address(keyword, match)
+    try:
+        vanity_account = generate_vanity_address(keyword, match)
+    except KeyboardInterrupt as ex:
+        click.echo("\nAborting vanity address generation...")
+        raise click.Abort from ex
 
     if output == "stdout":
         logger.warning(

--- a/src/algokit/core/tasks/vanity_address.py
+++ b/src/algokit/core/tasks/vanity_address.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from multiprocessing import Manager, Pool, cpu_count
@@ -21,6 +22,15 @@ class MatchType(Enum):
     END = "end"
 
 
+MatchFunction = Callable[[str, str], bool]
+
+MATCH_FUNCTIONS: dict[MatchType, MatchFunction] = {
+    MatchType.START: lambda addr, keyword: addr.startswith(keyword),
+    MatchType.ANYWHERE: lambda addr, keyword: keyword in addr,
+    MatchType.END: lambda addr, keyword: addr.endswith(keyword),
+}
+
+
 @dataclass
 class VanityAccount:
     mnemonic: str
@@ -36,9 +46,12 @@ def _log_progress(shared_data: DictProxy, stop_event: EventClass, start_time: fl
         total_count = sum(count.value for count in shared_data["counts"])
         if timer() - last_log_time >= PROGRESS_REFRESH_INTERVAL_SECONDS:
             elapsed_time = timer() - start_time
-            logger.info(
-                f"Still searching for a match. Iterated over {total_count} addresses in {elapsed_time:.2f} seconds."
+            message = (
+                f"Iterated over ~{total_count} addresses in {elapsed_time:.2f} seconds."
+                if total_count > 0
+                else f"Elapsed time: {elapsed_time:.2f} seconds."
             )
+            logger.info(f"Still searching for a match. {message}")
             last_log_time = timer()
         time.sleep(1)
 
@@ -59,20 +72,21 @@ def _search_for_matching_address(
         shared_data (DictProxy): A multiprocessing dictionary to share data between processes.
     """
 
+    local_count = 0
+    batch_size = 1000 * (cpu_count() - 1)
+
     while not stop_event.is_set():
         private_key, address = algosdk.account.generate_account()  # type: ignore[no-untyped-call]
-        generated_mnemonic = mnemonic.from_private_key(private_key)  # type: ignore[no-untyped-call]
 
-        match_conditions = {
-            MatchType.START: address.startswith(keyword),
-            MatchType.ANYWHERE: keyword in address,
-            MatchType.END: address.endswith(keyword),
-        }
+        local_count += 1
 
-        shared_data["counts"][worker_id].value += 1
+        if local_count % batch_size == 0:
+            shared_data["counts"][worker_id].value += local_count
+            local_count = 0
 
-        if match_conditions.get(match, False):
+        if MATCH_FUNCTIONS[match](address, keyword):
             stop_event.set()
+            generated_mnemonic = mnemonic.from_private_key(private_key)  # type: ignore[no-untyped-call]
             shared_data.update({"mnemonic": generated_mnemonic, "address": address})
             return
 
@@ -99,7 +113,8 @@ def generate_vanity_address(keyword: str, match: MatchType) -> VanityAccount:
     stop_event = manager.Event()
 
     start_time: float = timer()
-    with Pool(processes=num_processes) as pool:
+    pool = Pool(processes=num_processes)
+    try:
         for worker_id in range(num_processes - 1):
             pool.apply_async(_search_for_matching_address, (worker_id, keyword, match, stop_event, shared_data))
 
@@ -108,6 +123,11 @@ def generate_vanity_address(keyword: str, match: MatchType) -> VanityAccount:
 
         pool.close()
         pool.join()
+    except KeyboardInterrupt as ex:
+        stop_event.set()
+        pool.terminate()
+        pool.join()
+        raise ex
 
     logger.debug(f"Vanity address generation time: {timer() - start_time:.2f} seconds")
 

--- a/tests/tasks/test_vanity_address.py
+++ b/tests/tasks/test_vanity_address.py
@@ -101,8 +101,10 @@ def test_vanity_address_on_existing_alias(mock_keyring: dict[str, str]) -> None:
 
 def test_vanity_address_on_termination(mocker: MockerFixture) -> None:
     mock_pool = mocker.MagicMock()
-    mock_pool.apply_async.side_effect = KeyboardInterrupt()
-    mocker.patch("multiprocessing.Pool", return_value=mock_pool)
+    mock_pool.side_effect = KeyboardInterrupt()
+    # Mocking functions within the thread is tricky hence the use of side_effect on the range is used to simulate
+    # the KeyboardInterrupt
+    mocker.patch("algokit.core.tasks.vanity_address.range", side_effect=[range(2), KeyboardInterrupt()])
 
     result = invoke("task vanity-address AAAAAA")
 

--- a/tests/tasks/test_vanity_address.py
+++ b/tests/tasks/test_vanity_address.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from algokit.core.tasks.wallet import WALLET_ALIASES_KEYRING_USERNAME
+from pytest_mock import MockerFixture
 
 from tests.utils.approvals import verify
 from tests.utils.click_invoker import invoke
@@ -96,3 +97,14 @@ def test_vanity_address_on_existing_alias(mock_keyring: dict[str, str]) -> None:
     assert result.exit_code == 0
     assert json.loads(mock_keyring[alias])["alias"] == alias
     assert json.loads(mock_keyring[alias])["address"].startswith("A")
+
+
+def test_vanity_address_on_termination(mocker: MockerFixture) -> None:
+    mock_pool = mocker.MagicMock()
+    mock_pool.apply_async.side_effect = KeyboardInterrupt()
+    mocker.patch("multiprocessing.Pool", return_value=mock_pool)
+
+    result = invoke("task vanity-address AAAAAA")
+
+    assert result.exit_code == 1
+    verify(result.output)

--- a/tests/tasks/test_vanity_address.test_vanity_address_on_termination.approved.txt
+++ b/tests/tasks/test_vanity_address.test_vanity_address_on_termination.approved.txt
@@ -1,0 +1,3 @@
+
+Aborting vanity address generation...
+Aborted!


### PR DESCRIPTION
## Proposed changes

- Further testing with Rob on windows revealed performance issues with counter hence pr refactors the main generator function:
- - moving the matcher functions into a global variable with lambdas
- - reducing the rate at which shared counter values are accessed (depending on cpu)
- - adding error handling for keyboard interrupts + test case for confirming the cli output 