### PR TITLE
feat: transaction signing task; polishing tasks

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -680,7 +680,7 @@ algokit task [OPTIONS] COMMAND [ARGS]...
 
 ### sign
 
-Sign an Algorand transaction.
+Sign goal clerk compatible Algorand transaction(s).
 
 ```shell
 algokit task sign [OPTIONS]
@@ -690,19 +690,19 @@ algokit task sign [OPTIONS]
 
 
 ### -a, --account <account>
-**Required** The account alias.
+**Required** Address or alias of the signer account.
 
 
 ### -f, --file <file>
-The file to sign.
+Single or multiple message pack encoded transactions from binary file to sign. Option is mutually exclusive with transaction.
 
 
 ### -t, --transaction <transaction>
-The transaction to sign.
+Single base64 encoded transaction object to sign. Option is mutually exclusive with file.
 
 
 ### -o, --output <output>
-The output file.
+The output file path to store signed transaction(s).
 
 
 ### --force

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -98,8 +98,15 @@
     - [status](#status)
     - [stop](#stop)
   - [task](#task)
-    - [transfer](#transfer)
+    - [sign](#sign)
     - [Options](#options-17)
+    - [-a, --account ](#-a---account-)
+    - [-f, --file ](#-f---file--1)
+    - [-t, --transaction ](#-t---transaction-)
+    - [-o, --output ](#-o---output--2)
+    - [--force](#--force-1)
+    - [transfer](#transfer)
+    - [Options](#options-18)
     - [-s, --sender ](#-s---sender-)
     - [-r, --receiver ](#-r---receiver--1)
     - [--asset, --id ](#--asset---id-)
@@ -107,16 +114,16 @@
     - [--whole-units](#--whole-units-2)
     - [-n, --network ](#-n---network-)
     - [vanity-address](#vanity-address)
-    - [Options](#options-18)
+    - [Options](#options-19)
     - [-m, --match ](#-m---match-)
-    - [-o, --output ](#-o---output--2)
+    - [-o, --output ](#-o---output--3)
     - [-a, --alias ](#-a---alias-)
     - [--file-path ](#--file-path-)
     - [-f, --force](#-f---force)
     - [Arguments](#arguments-5)
     - [KEYWORD](#keyword)
     - [wallet](#wallet)
-    - [Options](#options-19)
+    - [Options](#options-20)
     - [-a, --address ](#-a---address-)
     - [-m, --mnemonic](#-m---mnemonic)
     - [-f, --force](#-f---force-1)
@@ -124,11 +131,11 @@
     - [ALIAS_NAME](#alias_name)
     - [Arguments](#arguments-7)
     - [ALIAS](#alias)
-    - [Options](#options-20)
+    - [Options](#options-21)
     - [-f, --force](#-f---force-2)
     - [Arguments](#arguments-8)
     - [ALIAS](#alias-1)
-    - [Options](#options-21)
+    - [Options](#options-22)
     - [-f, --force](#-f---force-3)
 
 # algokit
@@ -671,6 +678,36 @@ Collection of useful tasks to help you develop on Algorand.
 algokit task [OPTIONS] COMMAND [ARGS]...
 ```
 
+### sign
+
+Sign an Algorand transaction.
+
+```shell
+algokit task sign [OPTIONS]
+```
+
+### Options
+
+
+### -a, --account <account>
+**Required** The account alias.
+
+
+### -f, --file <file>
+The file to sign.
+
+
+### -t, --transaction <transaction>
+The transaction to sign.
+
+
+### -o, --output <output>
+The output file.
+
+
+### --force
+Force signing without confirmation.
+
 ### transfer
 
 Transfer algos or assets from one account to another.
@@ -683,19 +720,19 @@ algokit task transfer [OPTIONS]
 
 
 ### -s, --sender <sender>
-**Required** Address or alias of the sender account
+**Required** Address or alias of the sender account.
 
 
 ### -r, --receiver <receiver>
-**Required** Address or alias to an account that will receive the asset(s)
+**Required** Address or alias to an account that will receive the asset(s).
 
 
 ### --asset, --id <asset_id>
-ASA asset id to transfer
+ASA asset id to transfer.
 
 
 ### -a, --amount <amount>
-**Required** Amount to transfer
+**Required** Amount to transfer.
 
 
 ### --whole-units
@@ -782,15 +819,15 @@ algokit task wallet add [OPTIONS] ALIAS_NAME
 
 
 ### -a, --address <address>
-**Required** The address of the account
+**Required** The address of the account.
 
 
 ### -m, --mnemonic
-If specified then prompt the user for a mnemonic phrase interactively using masked input
+If specified then prompt the user for a mnemonic phrase interactively using masked input.
 
 
 ### -f, --force
-Allow overwriting an existing alias
+Allow overwriting an existing alias.
 
 ### Arguments
 
@@ -832,7 +869,7 @@ algokit task wallet remove [OPTIONS] ALIAS
 
 
 ### -f, --force
-Allow removing an alias without confirmation
+Allow removing an alias without confirmation.
 
 ### Arguments
 
@@ -852,4 +889,4 @@ algokit task wallet reset [OPTIONS]
 
 
 ### -f, --force
-Allow removing all aliases without confirmation
+Allow removing all aliases without confirmation.

--- a/docs/features/tasks.md
+++ b/docs/features/tasks.md
@@ -8,7 +8,7 @@ AlgoKit Tasks are a collection of handy tasks that can be used to perform variou
 - [Vanity Address Generation](./tasks/vanity.md) - Generate vanity addresses for your Algorand accounts with the AlgoKit Vanity feature. This feature allows you to generate Algorand addresses with a custom prefix of your choice.
 - [Transfer Assets or Algos](./tasks/transfer.md) - Transfer Algos or Assets from one account to another with the AlgoKit Transfer feature. This feature allows you to transfer Algos or Assets from one account to another on Algorand blockchain.
 - Opt-in or opt-out of Algorand Assets - Coming soon!
-- Signing transactions - Coming soon!
+- [Signing transactions](./tasks/sign.md) - Sign goal clerk compatible Algorand transactions.
 - Sending transactions - Coming soon!
 - NFD lookups - Coming soon!
 - IPFS uploads - Coming soon!

--- a/docs/features/tasks/sign.md
+++ b/docs/features/tasks/sign.md
@@ -1,0 +1,90 @@
+# AlgoKit Task Sign
+
+The AlgoKit Sign feature allows you to sign Algorand transaction(s) using the AlgoKit CLI. This feature supports signing single or multiple transactions, either provided directly as a base64 encoded string or from a binary file.
+
+## Usage
+
+Available commands and possible usage as follows:
+
+```bash
+$ ~ algokit task sign
+Usage: algokit task sign [OPTIONS]
+
+Sign goal clerk compatible Algorand transaction(s).
+
+Options:
+-a, --account TEXT Address or alias of the signer account. [required]
+-f, --file PATH Single or multiple message pack encoded transactions from binary file to sign.
+-t, --transaction TEXT Single base64 encoded transaction object to sign.
+-o, --output PATH The output file path to store signed transaction(s).
+--force Force signing without confirmation.
+-h, --help Show this message and exit.
+```
+
+## Options
+
+- `--account, -a TEXT`: Specifies the address or alias of the signer account. This option is required.
+- `--file, -f PATH`: Specifies the path to a binary file containing single or multiple message pack encoded transactions to sign. Mutually exclusive with `--transaction` option.
+- `--transaction, -t TEXT`: Specifies a single base64 encoded transaction object to sign. Mutually exclusive with `--file` option.
+- `--output, -o PATH`: Specifies the output file path to store signed transaction(s).
+- `--force`: If specified, it allows signing without interactive confirmation prompt.
+
+> Please note, `--transaction` flag only supports signing a single transaction. If you want to sign multiple transactions, you can use the `--file` flag to specify a binary file containing multiple transactions.
+
+## Example
+
+To sign a transaction, you can use the `sign` command as follows:
+
+```bash
+$ algokit task sign --account {YOUR_ACCOUNT_ALIAS OR YOUR_ADDRESS} --file {PATH_TO_BINARY_FILE_CONTAINING_TRANSACTIONS}
+```
+
+This will prompt you to confirm the transaction details before signing. If you want to bypass the confirmation, you can use the `--force` flag:
+
+```bash
+$ algokit task sign --account {YOUR_ACCOUNT_ALIAS OR YOUR_ADDRESS} --transaction {YOUR_BASE64_ENCODED_TRANSACTION} --force
+```
+
+If the transaction is successfully signed, the signed transaction will be output to the console in a JSON format. If you want to write the signed transaction to a file, you can use the `--output` option:
+
+```bash
+$ algokit task sign --account {YOUR_ACCOUNT_ALIAS OR YOUR_ADDRESS} --transaction {YOUR_BASE64_ENCODED_TRANSACTION} --output /path/to/output/file
+```
+
+This will write the signed transaction to the specified file.
+
+## Goal Compatibility
+
+Please note, at the moment this feature only supports [`goal clerk`](https://developer.algorand.org/docs/clis/goal/clerk/clerk/) compatible transaction objects.
+
+When `--output` option is not specified, the signed transaction(s) will be output to the console in a following JSON format:
+
+```
+[
+  {txn_id: "TRANSACTION_ID", content: "BASE64_ENCODED_SIGNED_TRANSACTION"},
+]
+```
+
+On the other hand, when `--output` option is specified, the signed transaction(s) will be stored to a file as a message pack encoded binary file.
+
+### Encoding transactins for signing
+
+Algorand provides a set of options in [py-algorand-sdk](https://github.com/algorand/py-algorand-sdk) and [js-algorand-sdk](https://github.com/algorand/js-algorand-sdk) to encode transactions for signing.
+
+Encoding simple txn object in python:
+
+```py
+# Encoding single transaction as a base64 encoded string
+algosdk.encoding.msgpack_encode({"txn": {YOUR_TXN_OBJECT}.dictify()}) # Resulting string can be passed directy to algokit task sign with --transaction flag
+
+# Encoding multiple transactions as a message pack encoded binary file
+algosdk.transaction.write_to_file([{YOUR_TXN_OBJECT}], "some_file.txn") # Resulting file path can be passed directly to algokit sign with --file flag
+```
+
+Encoding simple txn object in javascript:
+
+```ts
+Buffer.from(algosdk.encodeObj({ txn: txn.get_obj_for_encoding() })).toString(
+  "base64"
+); // Resulting string can be passed directy to algokit task sign with --transaction flag
+```

--- a/src/algokit/cli/common/utils.py
+++ b/src/algokit/cli/common/utils.py
@@ -1,0 +1,81 @@
+# Cli/Click related helper functions and classes
+
+
+import typing as t
+
+import click
+
+
+class MutuallyExclusiveOption(click.Option):
+    """
+    A Click option that defines mutually exclusive command line options.
+
+    Args:
+        *args: Positional arguments passed to the parent class constructor.
+        **kwargs: Keyword arguments passed to the parent class constructor.
+            not_required_if (list): A list of options that the current option is mutually exclusive with.
+
+    Attributes:
+        not_required_if (list): A list of options that the current option is mutually exclusive with.
+
+    Raises:
+        AssertionError: If the `not_required_if` parameter is not provided.
+
+    Example:
+        ```python
+        @click.command()
+        @click.option('--option1', help='Option 1')
+        @click.option('--option2', help='Option 2')
+        @click.option('--option3', help='Option 3', cls=MutuallyExclusiveOption, not_required_if=['option1', 'option2'])
+        def my_command(option1, option2, option3):
+            # Command logic here
+            pass
+        ```
+
+        In the example above, the `MutuallyExclusiveOption` class is used to define the `option3` command line option.
+        This option is mutually exclusive with `option1` and `option2`,
+        meaning that if either `option1` or `option2` is provided, `option3` cannot be used.
+        If `option3` is provided along with `option1` or `option2`, a `click.UsageError` is raised.
+    """
+
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        self.not_required_if: list = kwargs.pop("not_required_if")
+
+        assert self.not_required_if, "'not_required_if' parameter required"
+        kwargs["help"] = (
+            kwargs.get("help", "") + " Option is mutually exclusive with " + ", ".join(self.not_required_if) + "."
+        ).strip()
+        super().__init__(*args, **kwargs)
+
+    def handle_parse_result(
+        self, ctx: click.Context, opts: t.Mapping[str, t.Any], args: list[str]
+    ) -> tuple[t.Any, list[str]]:
+        """
+        Overrides the `handle_parse_result` method of the `click.Option` class.
+
+        This method checks if the current option is present in the provided options (`opts`)
+        and if any of the mutually exclusive options are also present.
+        If both the current option and a mutually exclusive option are present, it raises a `click.UsageError`.
+        Otherwise, it returns the result of the parent `handle_parse_result` method.
+
+        Args:
+            ctx (click.Context): The Click context object.
+            opts (dict): The dictionary of parsed options.
+            args (list): The list of remaining arguments.
+
+        Returns:
+            The result of the parent `handle_parse_result` method.
+
+        Raises:
+            click.UsageError: If the current option and a mutually exclusive option are both present.
+        """
+
+        current_opt: bool = self.name in opts
+        for mutex_opt in self.not_required_if:
+            if mutex_opt in opts:
+                if current_opt:
+                    raise click.UsageError(
+                        "Illegal usage: '" + str(self.name) + "' is mutually exclusive with " + str(mutex_opt) + "."
+                    )
+                self.prompt = None
+        return super().handle_parse_result(ctx, opts, args)

--- a/src/algokit/cli/generate.py
+++ b/src/algokit/cli/generate.py
@@ -119,7 +119,7 @@ def generate_client(output_path_pattern: str | None, app_spec_path_or_dir: Path,
             ) from ex
     else:
         raise click.ClickException(
-            "One of --language or --output is required to determine the client langauge to generate"
+            "One of --language or --output is required to determine the client language to generate"
         )
 
     if not app_spec_path_or_dir.is_dir():

--- a/src/algokit/cli/task.py
+++ b/src/algokit/cli/task.py
@@ -2,6 +2,7 @@ import logging
 
 import click
 
+from algokit.cli.tasks.sign_transaction import sign
 from algokit.cli.tasks.transfer import transfer
 from algokit.cli.tasks.vanity_address import vanity_address
 from algokit.cli.tasks.wallet import wallet
@@ -17,3 +18,4 @@ def task_group() -> None:
 task_group.add_command(wallet)
 task_group.add_command(vanity_address)
 task_group.add_command(transfer)
+task_group.add_command(sign)

--- a/src/algokit/cli/tasks/sign_transaction.py
+++ b/src/algokit/cli/tasks/sign_transaction.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+from typing import cast
+
+import click
+from algosdk import encoding
+from algosdk.transaction import Transaction, retrieve_from_file, write_to_file
+
+from algokit.cli.tasks.utils import get_account_with_private_key
+
+
+def get_transaction(file: Path | None, transaction: str | None) -> Transaction:
+    if file:
+        txns: list[Transaction] = retrieve_from_file(str(file))  # type: ignore[no-untyped-call]
+        if len(txns) > 1:
+            raise click.ClickException("Only one transaction per file is supported.")
+        return txns[0]
+    elif transaction:
+        return cast(Transaction, encoding.msgpack_decode(transaction))  # type: ignore[no-untyped-call]
+    else:
+        raise click.ClickException("Provide either a file to sign or a transaction to sign, not both or none.")
+
+
+def confirm_transaction(txn: Transaction) -> bool:
+    click.echo(json.dumps(txn.__dict__, indent=2))
+    response = click.prompt("Do you want to sign the above transaction?", type=click.Choice(["y", "n"]), default="n")
+    return bool(response == "y")
+
+
+def sign_and_output_transaction(txn: Transaction, private_key: str, output: Path | None) -> None:
+    signed_txn = txn.sign(private_key)  # type: ignore[no-untyped-call]
+
+    if output:
+        write_to_file([signed_txn], str(output))  # type: ignore[no-untyped-call]
+        click.echo(f"Signed transaction written to {output}")
+    else:
+        click.echo(encoding.msgpack_encode({"txn": signed_txn.dictify()}))  # type: ignore[no-untyped-call]
+
+
+@click.command(name="sign", help="Sign an Algorand transaction.")
+@click.option("--account", "-a", type=str, required=True, help="The account alias.")
+@click.option(
+    "--file",
+    "-f",
+    type=Path,
+    help="The file to sign.",
+    required=False,
+)
+@click.option("--transaction", "-t", type=str, help="The transaction to sign.", required=False)
+@click.option("--output", "-o", type=Path, help="The output file.", required=False)
+@click.option("--force", is_flag=True, help="Force signing without confirmation.", required=False)
+def sign(*, account: str, file: Path | None, transaction: str | None, output: Path | None, force: bool) -> None:
+    signer_account = get_account_with_private_key(account)
+
+    if bool(file) == bool(transaction):
+        raise click.ClickException("Provide either a file to sign or a transaction to sign, not both or none.")
+
+    txn: Transaction = get_transaction(file, transaction)
+
+    if not force and not confirm_transaction(txn):
+        return
+
+    sign_and_output_transaction(txn, signer_account.private_key, output)

--- a/src/algokit/cli/tasks/transfer.py
+++ b/src/algokit/cli/tasks/transfer.py
@@ -1,23 +1,24 @@
 import logging
 from typing import TYPE_CHECKING
 
-import algosdk
-import algosdk.encoding
 import click
 from algokit_utils import (
-    Account,
     TransferAssetParameters,
     TransferParameters,
-    get_algod_client,
-    get_algonode_config,
-    get_default_localnet_config,
     transfer_asset,
 )
 from algokit_utils import (
     transfer as transfer_algos,
 )
 
-from algokit.core.tasks.wallet import get_alias
+from algokit.cli.tasks.utils import (
+    get_account_with_private_key,
+    get_address,
+    get_asset_decimals,
+    load_algod_client,
+    validate_address,
+    validate_balance,
+)
 
 if TYPE_CHECKING:
     from algosdk.transaction import AssetTransferTxn, PaymentTxn
@@ -27,129 +28,19 @@ logger = logging.getLogger(__name__)
 # TODO: upon algokit nfd lookup being implemented receiver will also allow nfd lookups
 
 
-def _get_private_key_from_mnemonic() -> str:
-    mnemonic_phrase = click.prompt("Enter the mnemonic phrase (25 words separated by whitespace)", hide_input=True)
-    try:
-        return str(algosdk.mnemonic.to_private_key(mnemonic_phrase))  # type: ignore[no-untyped-call]
-    except Exception as err:
-        raise click.ClickException("Invalid mnemonic. Please provide a valid Algorand mnemonic.") from err
-
-
-def _get_algod_client(network: str) -> algosdk.v2client.algod.AlgodClient:
-    config_mapping = {
-        "localnet": get_default_localnet_config("algod"),
-        "testnet": get_algonode_config("testnet", "algod", ""),
-        "mainnet": get_algonode_config("mainnet", "algod", ""),
-    }
-    try:
-        return get_algod_client(config_mapping[network])
-    except KeyError as err:
-        raise click.ClickException("Invalid network") from err
-
-
-def _get_asset_decimals(asset_id: int, algod_client: algosdk.v2client.algod.AlgodClient) -> int:
-    if asset_id == 0:
-        return 6
-
-    asset_info = algod_client.asset_info(asset_id)
-
-    if not isinstance(asset_info, dict) or "params" not in asset_info or "decimals" not in asset_info["params"]:
-        raise click.ClickException("Invalid asset info response")
-
-    return int(asset_info["params"]["decimals"])
-
-
-def _validate_address(address: str) -> None:
-    if not algosdk.encoding.is_valid_address(address):  # type: ignore[no-untyped-call]
-        raise click.ClickException(f"{address} is an invalid account address")
-
-
-def _validate_asset_balance(sender_account_info: dict, receiver_account_info: dict, asset_id: int, amount: int) -> None:
-    sender_asset_record = next(
-        (asset for asset in sender_account_info.get("assets", []) if asset["asset-id"] == asset_id), None
-    )
-    receiver_asset_record = next(
-        (asset for asset in receiver_account_info.get("assets", []) if asset["asset-id"] == asset_id), None
-    )
-    if not sender_asset_record:
-        raise click.ClickException("Sender is not opted into the asset")
-    if sender_asset_record["amount"] < amount:
-        raise click.ClickException("Insufficient asset balance in sender account")
-    if not receiver_asset_record:
-        raise click.ClickException("Receiver is not opted into the asset")
-
-
-def _validate_algo_balance(sender_account_info: dict, amount: int) -> None:
-    if sender_account_info.get("amount", 0) < amount:
-        raise click.ClickException("Insufficient Algos balance in sender account")
-
-
-def _validate_balance(
-    sender: Account, receiver: str, asset_id: int, amount: int, algod_client: algosdk.v2client.algod.AlgodClient
-) -> None:
-    sender_account_info = algod_client.account_info(sender.address)
-    receiver_account_info = algod_client.account_info(receiver)
-
-    if not isinstance(sender_account_info, dict) or not isinstance(receiver_account_info, dict):
-        raise click.ClickException("Invalid account info response")
-
-    if asset_id == 0:
-        _validate_algo_balance(sender_account_info, amount)
-    else:
-        _validate_asset_balance(sender_account_info, receiver_account_info, asset_id, amount)
-
-
-def _validate_inputs(
-    sender: Account, receiver: str, asset_id: int, amount: int, algod_client: algosdk.v2client.algod.AlgodClient
-) -> None:
-    _validate_address(receiver)
-    _validate_balance(sender, receiver, asset_id, amount, algod_client)
-
-
-def _get_account_with_private_key(address: str) -> Account:
-    parsed_address = address.strip('"')
-
-    try:
-        _validate_address(parsed_address)
-        pk = _get_private_key_from_mnemonic()
-        return Account(address=parsed_address, private_key=pk)
-    except click.ClickException as ex:
-        alias_data = get_alias(parsed_address)
-
-        if not alias_data:
-            raise click.ClickException(f"Alias `{parsed_address}` alias does not exist.") from ex
-        if not alias_data.private_key:
-            raise click.ClickException(f"Alias `{parsed_address}` does not have a private key.") from ex
-
-        return Account(address=alias_data.address, private_key=alias_data.private_key)
-
-
-def _get_address(address: str) -> str:
-    parsed_address = address.strip('"')
-
-    try:
-        _validate_address(parsed_address)
-        return parsed_address
-    except click.ClickException as ex:
-        alias_data = get_alias(parsed_address)
-
-        if not alias_data:
-            raise click.ClickException(f"Alias `{parsed_address}` alias does not exist.") from ex
-
-        return alias_data.address
-
-
 @click.command(name="transfer", help="""Transfer algos or assets from one account to another.""")
-@click.option("--sender", "-s", type=click.STRING, help="Address or alias of the sender account", required=True)
+@click.option("--sender", "-s", type=click.STRING, help="Address or alias of the sender account.", required=True)
 @click.option(
     "--receiver",
     "-r",
     type=click.STRING,
-    help="Address or alias to an account that will receive the asset(s)",
+    help="Address or alias to an account that will receive the asset(s).",
     required=True,
 )
-@click.option("--asset", "--id", "asset_id", type=click.INT, help="ASA asset id to transfer", default=0, required=False)
-@click.option("--amount", "-a", type=click.INT, help="Amount to transfer", required=True)
+@click.option(
+    "--asset", "--id", "asset_id", type=click.INT, help="ASA asset id to transfer.", default=0, required=False
+)
+@click.option("--amount", "-a", type=click.INT, help="Amount to transfer.", required=True)
 @click.option(
     "--whole-units",
     "whole_units",
@@ -180,18 +71,19 @@ def transfer(  # noqa: PLR0913
     network: str,
 ) -> None:
     # Load addresses and accounts from mnemonics or aliases
-    sender_account = _get_account_with_private_key(sender)
-    receiver_address = _get_address(receiver)
+    sender_account = get_account_with_private_key(sender)
+    receiver_address = get_address(receiver)
 
     # Get algod client
-    algod_client = _get_algod_client(network)
+    algod_client = load_algod_client(network)
 
     # Convert amount to whole units if specified
     if whole_units:
-        amount = amount * (10 ** _get_asset_decimals(asset_id, algod_client))
+        amount = amount * (10 ** get_asset_decimals(asset_id, algod_client))
 
     # Validate inputs
-    _validate_inputs(sender_account, receiver_address, asset_id, amount, algod_client)
+    validate_address(receiver_address)
+    validate_balance(sender_account, receiver_address, asset_id, amount, algod_client)
 
     # Transfer algos or assets depending on asset_id
     txn_response: PaymentTxn | AssetTransferTxn | None = None

--- a/src/algokit/cli/tasks/utils.py
+++ b/src/algokit/cli/tasks/utils.py
@@ -15,44 +15,7 @@ from algokit.core.tasks.wallet import get_alias
 logger = logging.getLogger(__name__)
 
 
-def get_private_key_from_mnemonic() -> str:
-    mnemonic_phrase = click.prompt("Enter the mnemonic phrase (25 words separated by whitespace)", hide_input=True)
-    try:
-        return str(algosdk.mnemonic.to_private_key(mnemonic_phrase))  # type: ignore[no-untyped-call]
-    except Exception as err:
-        raise click.ClickException("Invalid mnemonic. Please provide a valid Algorand mnemonic.") from err
-
-
-def load_algod_client(network: str) -> algosdk.v2client.algod.AlgodClient:
-    config_mapping = {
-        "localnet": get_default_localnet_config("algod"),
-        "testnet": get_algonode_config("testnet", "algod", ""),
-        "mainnet": get_algonode_config("mainnet", "algod", ""),
-    }
-    try:
-        return get_algod_client(config_mapping[network])
-    except KeyError as err:
-        raise click.ClickException("Invalid network") from err
-
-
-def get_asset_decimals(asset_id: int, algod_client: algosdk.v2client.algod.AlgodClient) -> int:
-    if asset_id == 0:
-        return 6
-
-    asset_info = algod_client.asset_info(asset_id)
-
-    if not isinstance(asset_info, dict) or "params" not in asset_info or "decimals" not in asset_info["params"]:
-        raise click.ClickException("Invalid asset info response")
-
-    return int(asset_info["params"]["decimals"])
-
-
-def validate_address(address: str) -> None:
-    if not algosdk.encoding.is_valid_address(address):  # type: ignore[no-untyped-call]
-        raise click.ClickException(f"{address} is an invalid account address")
-
-
-def validate_asset_balance(sender_account_info: dict, receiver_account_info: dict, asset_id: int, amount: int) -> None:
+def _validate_asset_balance(sender_account_info: dict, receiver_account_info: dict, asset_id: int, amount: int) -> None:
     sender_asset_record = next(
         (asset for asset in sender_account_info.get("assets", []) if asset["asset-id"] == asset_id), None
     )
@@ -67,14 +30,117 @@ def validate_asset_balance(sender_account_info: dict, receiver_account_info: dic
         raise click.ClickException("Receiver is not opted into the asset")
 
 
-def validate_algo_balance(sender_account_info: dict, amount: int) -> None:
+def _validate_algo_balance(sender_account_info: dict, amount: int) -> None:
     if sender_account_info.get("amount", 0) < amount:
         raise click.ClickException("Insufficient Algos balance in sender account")
+
+
+def get_private_key_from_mnemonic() -> str:
+    """
+    Converts a mnemonic phrase into a private key.
+
+    Returns:
+        str: The private key generated from the mnemonic phrase.
+
+    Raises:
+        click.ClickException: If the entered mnemonic phrase is invalid.
+
+    Example Usage:
+        private_key = get_private_key_from_mnemonic()
+        print(private_key)
+
+    Inputs:
+        None
+
+    Flow:
+        1. Prompts the user to enter a mnemonic phrase.
+        2. Converts the entered mnemonic phrase into a private key using `algosdk.mnemonic.to_private_key`.
+        3. Returns the private key.
+
+    """
+
+    mnemonic_phrase = click.prompt("Enter the mnemonic phrase (25 words separated by whitespace)", hide_input=True)
+    try:
+        return str(algosdk.mnemonic.to_private_key(mnemonic_phrase))  # type: ignore[no-untyped-call]
+    except Exception as err:
+        raise click.ClickException("Invalid mnemonic. Please provide a valid Algorand mnemonic.") from err
+
+
+def load_algod_client(network: str) -> algosdk.v2client.algod.AlgodClient:
+    """
+    Returns an instance of the `algosdk.v2client.algod.AlgodClient` class for the specified network.
+
+    Args:
+        network (str): The network for which the `AlgodClient` instance needs to be loaded.
+
+    Returns:
+        algosdk.v2client.algod.AlgodClient: An instance of the `AlgodClient` class for the specified network.
+
+    Raises:
+        click.ClickException: If the specified network is invalid.
+    """
+
+    config_mapping = {
+        "localnet": get_default_localnet_config("algod"),
+        "testnet": get_algonode_config("testnet", "algod", ""),
+        "mainnet": get_algonode_config("mainnet", "algod", ""),
+    }
+    try:
+        return get_algod_client(config_mapping[network])
+    except KeyError as err:
+        raise click.ClickException("Invalid network") from err
+
+
+def get_asset_decimals(asset_id: int, algod_client: algosdk.v2client.algod.AlgodClient) -> int:
+    """
+    Retrieves the number of decimal places for a given asset.
+
+    Args:
+        asset_id (int): The ID of the asset for which the number of decimal places is to be retrieved. (0 for Algo)
+        algod_client (algosdk.v2client.algod.AlgodClient): An instance of the AlgodClient class.
+
+    Returns:
+        int: The number of decimal places for the given asset.
+
+    Raises:
+        click.ClickException: If the asset info response is invalid.
+
+    Example:
+        asset_id = 123
+        algod_client = algosdk.v2client.algod.AlgodClient("https://api.algoexplorer.io", "API_KEY")
+        decimals = get_asset_decimals(asset_id, algod_client)
+        print(decimals)
+    """
+
+    if asset_id == 0:
+        return 6
+
+    asset_info = algod_client.asset_info(asset_id)
+
+    if not isinstance(asset_info, dict) or "params" not in asset_info or "decimals" not in asset_info["params"]:
+        raise click.ClickException("Invalid asset info response")
+
+    return int(asset_info["params"]["decimals"])
 
 
 def validate_balance(
     sender: Account, receiver: str, asset_id: int, amount: int, algod_client: algosdk.v2client.algod.AlgodClient
 ) -> None:
+    """
+    Validates the balance of a sender's account before transferring assets or Algos to a receiver's account.
+
+    Args:
+        sender (Account): The sender's account object.
+        receiver (str): The receiver's account address.
+        asset_id (int): The ID of the asset to be transferred (0 for Algos).
+        amount (int): The amount of Algos or asset to be transferred.
+        algod_client (algosdk.v2client.algod.AlgodClient): The AlgodClient object for
+        interacting with the Algorand blockchain.
+
+    Raises:
+        click.ClickException: If any validation check fails.
+    """
+
     sender_account_info = algod_client.account_info(sender.address)
     receiver_account_info = algod_client.account_info(receiver)
 
@@ -82,12 +148,43 @@ def validate_balance(
         raise click.ClickException("Invalid account info response")
 
     if asset_id == 0:
-        validate_algo_balance(sender_account_info, amount)
+        _validate_algo_balance(sender_account_info, amount)
     else:
-        validate_asset_balance(sender_account_info, receiver_account_info, asset_id, amount)
+        _validate_asset_balance(sender_account_info, receiver_account_info, asset_id, amount)
+
+
+def validate_address(address: str) -> None:
+    """
+    Check if a given address is a valid Algorand account address.
+
+    Args:
+        address (str): The address to be validated.
+
+    Raises:
+        click.ClickException: If the address is invalid.
+
+    Returns:
+        None
+    """
+
+    if not algosdk.encoding.is_valid_address(address):  # type: ignore[no-untyped-call]
+        raise click.ClickException(f"`{address}` is an invalid account address")
 
 
 def get_account_with_private_key(address: str) -> Account:
+    """
+    Retrieves an account object with the private key based on the provided address.
+
+    Args:
+        address (str): The address for which to retrieve the account object.
+
+    Returns:
+        Account: An account object with the address and private key.
+
+    Raises:
+        click.ClickException: If the address is not valid or if the alias does not exist or does not have a private key.
+    """
+
     parsed_address = address.strip('"')
 
     try:
@@ -106,6 +203,24 @@ def get_account_with_private_key(address: str) -> Account:
 
 
 def get_address(address: str) -> str:
+    """
+    Validates the given address and returns it if valid. If the address is not valid,
+    it checks if the address is an alias and returns the corresponding address if the alias exists.
+
+    Args:
+        address (str): The address to be validated or checked for an alias.
+
+    Returns:
+        str: The validated address or the corresponding address from an alias.
+
+    Raises:
+        click.ClickException: If the address is not valid and no corresponding alias exists.
+
+    Example:
+        address = get_address("ABCD1234")
+        print(address)
+    """
+
     parsed_address = address.strip('"')
 
     try:

--- a/src/algokit/cli/tasks/utils.py
+++ b/src/algokit/cli/tasks/utils.py
@@ -1,0 +1,120 @@
+import logging
+
+import algosdk
+import algosdk.encoding
+import click
+from algokit_utils import (
+    Account,
+    get_algod_client,
+    get_algonode_config,
+    get_default_localnet_config,
+)
+
+from algokit.core.tasks.wallet import get_alias
+
+logger = logging.getLogger(__name__)
+
+
+def get_private_key_from_mnemonic() -> str:
+    mnemonic_phrase = click.prompt("Enter the mnemonic phrase (25 words separated by whitespace)", hide_input=True)
+    try:
+        return str(algosdk.mnemonic.to_private_key(mnemonic_phrase))  # type: ignore[no-untyped-call]
+    except Exception as err:
+        raise click.ClickException("Invalid mnemonic. Please provide a valid Algorand mnemonic.") from err
+
+
+def load_algod_client(network: str) -> algosdk.v2client.algod.AlgodClient:
+    config_mapping = {
+        "localnet": get_default_localnet_config("algod"),
+        "testnet": get_algonode_config("testnet", "algod", ""),
+        "mainnet": get_algonode_config("mainnet", "algod", ""),
+    }
+    try:
+        return get_algod_client(config_mapping[network])
+    except KeyError as err:
+        raise click.ClickException("Invalid network") from err
+
+
+def get_asset_decimals(asset_id: int, algod_client: algosdk.v2client.algod.AlgodClient) -> int:
+    if asset_id == 0:
+        return 6
+
+    asset_info = algod_client.asset_info(asset_id)
+
+    if not isinstance(asset_info, dict) or "params" not in asset_info or "decimals" not in asset_info["params"]:
+        raise click.ClickException("Invalid asset info response")
+
+    return int(asset_info["params"]["decimals"])
+
+
+def validate_address(address: str) -> None:
+    if not algosdk.encoding.is_valid_address(address):  # type: ignore[no-untyped-call]
+        raise click.ClickException(f"{address} is an invalid account address")
+
+
+def validate_asset_balance(sender_account_info: dict, receiver_account_info: dict, asset_id: int, amount: int) -> None:
+    sender_asset_record = next(
+        (asset for asset in sender_account_info.get("assets", []) if asset["asset-id"] == asset_id), None
+    )
+    receiver_asset_record = next(
+        (asset for asset in receiver_account_info.get("assets", []) if asset["asset-id"] == asset_id), None
+    )
+    if not sender_asset_record:
+        raise click.ClickException("Sender is not opted into the asset")
+    if sender_asset_record["amount"] < amount:
+        raise click.ClickException("Insufficient asset balance in sender account")
+    if not receiver_asset_record:
+        raise click.ClickException("Receiver is not opted into the asset")
+
+
+def validate_algo_balance(sender_account_info: dict, amount: int) -> None:
+    if sender_account_info.get("amount", 0) < amount:
+        raise click.ClickException("Insufficient Algos balance in sender account")
+
+
+def validate_balance(
+    sender: Account, receiver: str, asset_id: int, amount: int, algod_client: algosdk.v2client.algod.AlgodClient
+) -> None:
+    sender_account_info = algod_client.account_info(sender.address)
+    receiver_account_info = algod_client.account_info(receiver)
+
+    if not isinstance(sender_account_info, dict) or not isinstance(receiver_account_info, dict):
+        raise click.ClickException("Invalid account info response")
+
+    if asset_id == 0:
+        validate_algo_balance(sender_account_info, amount)
+    else:
+        validate_asset_balance(sender_account_info, receiver_account_info, asset_id, amount)
+
+
+def get_account_with_private_key(address: str) -> Account:
+    parsed_address = address.strip('"')
+
+    try:
+        validate_address(parsed_address)
+        pk = get_private_key_from_mnemonic()
+        return Account(address=parsed_address, private_key=pk)
+    except click.ClickException as ex:
+        alias_data = get_alias(parsed_address)
+
+        if not alias_data:
+            raise click.ClickException(f"Alias `{parsed_address}` alias does not exist.") from ex
+        if not alias_data.private_key:
+            raise click.ClickException(f"Alias `{parsed_address}` does not have a private key.") from ex
+
+        return Account(address=alias_data.address, private_key=alias_data.private_key)
+
+
+def get_address(address: str) -> str:
+    parsed_address = address.strip('"')
+
+    try:
+        validate_address(parsed_address)
+        return parsed_address
+    except click.ClickException as ex:
+        alias_data = get_alias(parsed_address)
+
+        if not alias_data:
+            raise click.ClickException(f"Alias `{parsed_address}` alias does not exist.") from ex
+
+        return alias_data.address

--- a/src/algokit/cli/tasks/wallet.py
+++ b/src/algokit/cli/tasks/wallet.py
@@ -2,8 +2,9 @@ import json
 import re
 
 import click
-from algosdk import account, encoding, mnemonic
+from algosdk import account
 
+from algokit.cli.tasks.utils import get_private_key_from_mnemonic, validate_address
 from algokit.core.tasks.wallet import (
     WALLET_ALIASING_MAX_LIMIT,
     WalletAliasingLimitError,
@@ -21,19 +22,6 @@ def _validate_alias_name(alias_name: str) -> None:
             "Invalid alias name. It should have at most 20 characters consisting of numbers, "
             "letters, dashes, or underscores."
         )
-
-
-def _validate_address(address: str) -> None:
-    if not encoding.is_valid_address(address):  # type: ignore[no-untyped-call]
-        raise click.ClickException("Invalid address. Please provide a valid Algorand address.")
-
-
-def _get_private_key_from_mnemonic() -> str:
-    mnemonic_phrase = click.prompt("Enter the mnemonic phrase (25 words separated by whitespace)", hide_input=True)
-    try:
-        return str(mnemonic.to_private_key(mnemonic_phrase))  # type: ignore[no-untyped-call]
-    except ValueError as err:
-        raise click.ClickException("Invalid mnemonic. Please provide a valid Algorand mnemonic.") from err
 
 
 @click.group()
@@ -56,9 +44,9 @@ def add(*, alias_name: str, address: str, use_mnemonic: bool, force: bool) -> No
     """Add an address or account to be stored against a named alias (at most 50 aliases)."""
 
     _validate_alias_name(alias_name)
-    _validate_address(address)
+    validate_address(address)
 
-    private_key = _get_private_key_from_mnemonic() if use_mnemonic else None
+    private_key = get_private_key_from_mnemonic() if use_mnemonic else None
 
     if use_mnemonic:
         derived_address = account.address_from_private_key(private_key)  # type: ignore[no-untyped-call]

--- a/src/algokit/cli/tasks/wallet.py
+++ b/src/algokit/cli/tasks/wallet.py
@@ -43,15 +43,15 @@ def wallet() -> None:
 
 @wallet.command("add")
 @click.argument("alias_name", type=click.STRING)
-@click.option("--address", "-a", type=click.STRING, required=True, help="The address of the account")
+@click.option("--address", "-a", type=click.STRING, required=True, help="The address of the account.")
 @click.option(
     "--mnemonic",
     "-m",
     "use_mnemonic",
     is_flag=True,
-    help="If specified then prompt the user for a mnemonic phrase interactively using masked input",
+    help="If specified then prompt the user for a mnemonic phrase interactively using masked input.",
 )
-@click.option("--force", "-f", is_flag=True, help="Allow overwriting an existing alias")
+@click.option("--force", "-f", is_flag=True, help="Allow overwriting an existing alias.")
 def add(*, alias_name: str, address: str, use_mnemonic: bool, force: bool) -> None:
     """Add an address or account to be stored against a named alias (at most 50 aliases)."""
 
@@ -128,7 +128,7 @@ def list_all() -> None:
 
 @wallet.command("remove")
 @click.argument("alias", type=click.STRING)
-@click.option("--force", "-f", is_flag=True, help="Allow removing an alias without confirmation")
+@click.option("--force", "-f", is_flag=True, help="Allow removing an alias without confirmation.")
 def remove(*, alias: str, force: bool) -> None:
     """Remove an address or account stored against a named alias."""
 
@@ -153,7 +153,7 @@ def remove(*, alias: str, force: bool) -> None:
 
 
 @wallet.command("reset")
-@click.option("--force", "-f", is_flag=True, help="Allow removing all aliases without confirmation")
+@click.option("--force", "-f", is_flag=True, help="Allow removing all aliases without confirmation.")
 def reset(*, force: bool) -> None:
     """Remove all aliases."""
 

--- a/tests/generate/test_generate_client.test_generate_no_options.approved.txt
+++ b/tests/generate/test_generate_client.test_generate_no_options.approved.txt
@@ -1,1 +1,1 @@
-Error: One of --language or --output is required to determine the client langauge to generate
+Error: One of --language or --output is required to determine the client language to generate

--- a/tests/tasks/TestAddAlias.test_wallet_add_invalid_address.approved.txt
+++ b/tests/tasks/TestAddAlias.test_wallet_add_invalid_address.approved.txt
@@ -1,1 +1,1 @@
-Error: Invalid address. Please provide a valid Algorand address.
+Error: `invalid_address` is an invalid account address

--- a/tests/tasks/test_sign_transaction.py
+++ b/tests/tasks/test_sign_transaction.py
@@ -1,0 +1,191 @@
+import json
+
+import click
+import pytest
+from algokit.core.tasks.wallet import WALLET_ALIASES_KEYRING_USERNAME
+from algokit_utils import Account
+from algosdk import encoding, mnemonic, transaction
+
+from tests.utils.approvals import verify
+from tests.utils.click_invoker import invoke
+
+DUMMY_SUGGESTED_PARAMS = transaction.SuggestedParams(  # type: ignore[no-untyped-call]
+    fee=0,
+    first=33652328,
+    last=33653328,
+    gen="testnet-v1.0",
+    gh="SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+    min_fee=1000,
+    flat_fee=True,
+    consensus_version="https://github.com/algorandfoundation/specs/tree/abd3d4823c6f77349fc04c3af7b1e99fe4df699f",
+)
+DUMMY_ACCOUNT = Account(
+    private_key="iLsfFiRDwi0ijFdvdyO1PGkYxooOanbJSgpJ4pPKjKZluk70pvuPX4dYD1Jir85uZP+AImM/8SBmdPRpBSTFAg==",
+    address="MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+)
+
+
+def _generate_dummy_txn(sender: str, amount: int = 1) -> transaction.PaymentTxn:
+    return transaction.PaymentTxn(sender, DUMMY_SUGGESTED_PARAMS, sender, amt=amount)  # type: ignore[no-untyped-call]
+
+
+def _get_mnemonic_from_private_key(private_key: str) -> str:
+    return str(mnemonic.from_private_key(private_key))  # type: ignore[no-untyped-call]
+
+
+def test_sign_atomic_txn_group_successful(
+    tmp_path_factory: pytest.TempPathFactory, mock_keyring: dict[str, str]
+) -> None:
+    # Arrange
+    cwd = tmp_path_factory.mktemp("cwd")
+    alias_name = "dummy_alias"
+    mock_keyring[alias_name] = json.dumps(
+        {"alias": alias_name, "address": DUMMY_ACCOUNT.address, "private_key": DUMMY_ACCOUNT.private_key}
+    )
+    mock_keyring[WALLET_ALIASES_KEYRING_USERNAME] = json.dumps([alias_name])
+    txn_a = _generate_dummy_txn(DUMMY_ACCOUNT.address)
+    txn_b = _generate_dummy_txn(DUMMY_ACCOUNT.address)
+    gid = transaction.calculate_group_id([txn_a, txn_b])  # type: ignore[no-untyped-call]
+    txn_a.group = gid
+    txn_b.group = gid
+    transaction.write_to_file([txn_a, txn_b], str(cwd / "dummy.txns"))  # type: ignore[no-untyped-call]
+
+    # Act
+    result = invoke(f"task sign -a {alias_name} --file dummy.txns", input="y", cwd=cwd)
+
+    # Assert
+    assert result.exit_code == 0
+    verify(result.output)
+
+
+def test_sign_from_stdin_with_alias_successful(mock_keyring: dict[str, str]) -> None:
+    # Arrange
+    alias_name = "dummy_alias"
+    mock_keyring[alias_name] = json.dumps(
+        {"alias": alias_name, "address": DUMMY_ACCOUNT.address, "private_key": DUMMY_ACCOUNT.private_key}
+    )
+    mock_keyring[WALLET_ALIASES_KEYRING_USERNAME] = json.dumps([alias_name])
+    dummy_txn = _generate_dummy_txn(DUMMY_ACCOUNT.address)
+
+    # Act
+    result = invoke(
+        f"task sign -a {alias_name} --transaction {encoding.msgpack_encode({'txn': dummy_txn.dictify()})}", input="y"  # type: ignore[no-untyped-call]  # noqa: E501
+    )
+
+    # Assert
+    assert result.exit_code == 0
+    verify(result.output)
+
+
+def test_sign_from_stdin_with_address_successful() -> None:
+    # Arrange
+    dummy_txn = _generate_dummy_txn(DUMMY_ACCOUNT.address)
+
+    # Act
+    result = invoke(
+        f"task sign -a {DUMMY_ACCOUNT.address} --transaction {encoding.msgpack_encode({'txn': dummy_txn.dictify()})}",  # type: ignore[no-untyped-call]  # noqa: E501
+        input=f"{_get_mnemonic_from_private_key(DUMMY_ACCOUNT.private_key)}\ny",
+    )
+
+    # Assert
+    assert result.exit_code == 0
+    verify(result.output)
+
+
+def test_sign_many_from_file_with_alias_successful(
+    tmp_path_factory: pytest.TempPathFactory, mock_keyring: dict[str, str]
+) -> None:
+    # Arrange
+    cwd = tmp_path_factory.mktemp("cwd")
+    alias_name = "dummy_alias"
+    mock_keyring[alias_name] = json.dumps(
+        {"alias": alias_name, "address": DUMMY_ACCOUNT.address, "private_key": DUMMY_ACCOUNT.private_key}
+    )
+    mock_keyring[WALLET_ALIASES_KEYRING_USERNAME] = json.dumps([alias_name])
+    _generate_dummy_txn(DUMMY_ACCOUNT.address)
+    transaction.write_to_file(  # type: ignore[no-untyped-call]
+        [
+            _generate_dummy_txn(DUMMY_ACCOUNT.address, 1),
+            _generate_dummy_txn(DUMMY_ACCOUNT.address, 2),
+            _generate_dummy_txn(DUMMY_ACCOUNT.address, 3),
+        ],
+        str(cwd / "dummy.txns"),
+    )
+
+    # Act
+    result = invoke(f"task sign -a {alias_name} --file dummy.txns", input="y", cwd=cwd)
+
+    # Assert
+    assert result.exit_code == 0
+    verify(result.output)
+
+
+def test_sign_many_from_file_with_address_successful(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    # Arrange
+    cwd = tmp_path_factory.mktemp("cwd")
+    _generate_dummy_txn(DUMMY_ACCOUNT.address)
+    transaction.write_to_file(  # type: ignore[no-untyped-call]
+        [
+            _generate_dummy_txn(DUMMY_ACCOUNT.address, 1),
+            _generate_dummy_txn(DUMMY_ACCOUNT.address, 2),
+            _generate_dummy_txn(DUMMY_ACCOUNT.address, 3),
+        ],
+        str(cwd / "dummy.txns"),
+    )
+
+    # Act
+    result = invoke(
+        f"task sign -a {DUMMY_ACCOUNT.address} --file dummy.txns",
+        input=f"{_get_mnemonic_from_private_key(DUMMY_ACCOUNT.private_key)}\ny",
+        cwd=cwd,
+    )
+
+    # Assert
+    assert result.exit_code == 0
+    verify(result.output)
+
+
+def test_mutually_exclusive_options() -> None:
+    # Arrange
+    _generate_dummy_txn(DUMMY_ACCOUNT.address)
+
+    # Act
+    result = invoke(
+        f"task sign -a {DUMMY_ACCOUNT.address} --file dummy.txns --transaction dummy.txn",
+        input=f"{_get_mnemonic_from_private_key(DUMMY_ACCOUNT.private_key)}\ny",
+    )
+
+    # Assert
+    assert result.exit_code == click.exceptions.UsageError.exit_code
+    verify(result.output)
+
+
+def test_file_decoding_errors(tmp_path_factory: pytest.TempPathFactory) -> None:
+    # Arrange
+    cwd = tmp_path_factory.mktemp("cwd")
+    (cwd / "dummy.txns").touch()
+
+    # Act
+    result = invoke(
+        f"task sign -a {DUMMY_ACCOUNT.address} --file dummy.txns",
+        input=f"{_get_mnemonic_from_private_key(DUMMY_ACCOUNT.private_key)}\ny",
+        cwd=cwd,
+    )
+
+    # Assert
+    assert result.exit_code == 1
+    verify(result.output)
+
+
+def test_transaction_decoding_errors() -> None:
+    # Act
+    result = invoke(
+        f"task sign -a {DUMMY_ACCOUNT.address} --transaction dummy",
+        input=f"{_get_mnemonic_from_private_key(DUMMY_ACCOUNT.private_key)}\ny",
+    )
+
+    # Assert
+    assert result.exit_code == 1
+    verify(result.output)

--- a/tests/tasks/test_sign_transaction.test_file_decoding_errors.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_file_decoding_errors.approved.txt
@@ -1,0 +1,2 @@
+Enter the mnemonic phrase (25 words separated by whitespace): 
+Error: No valid transactions found!

--- a/tests/tasks/test_sign_transaction.test_mutually_exclusive_options.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_mutually_exclusive_options.approved.txt
@@ -1,0 +1,1 @@
+Error: Illegal usage: 'file' is mutually exclusive with transaction.

--- a/tests/tasks/test_sign_transaction.test_sign_atomic_txn_group_successful.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_sign_atomic_txn_group_successful.approved.txt
@@ -1,0 +1,51 @@
+[
+  {
+    "txn_id": "RUU4DMAYJ5TLIEZ3ZT3PWTDPUOHCGOFY26JAXMOQXE52J2W6D7UA",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": "Vyhyt7HcQWkkBxcIR4zP+GkJLUAmN2H2D5Hx03fAVvo=",
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 1,
+      "close_remainder_to": null
+    }
+  },
+  {
+    "txn_id": "RUU4DMAYJ5TLIEZ3ZT3PWTDPUOHCGOFY26JAXMOQXE52J2W6D7UA",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": "Vyhyt7HcQWkkBxcIR4zP+GkJLUAmN2H2D5Hx03fAVvo=",
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 1,
+      "close_remainder_to": null
+    }
+  }
+]
+Would you like to proceed with signing the above? (y, n) [n]: y
+[
+  {
+    "txn_id": "RUU4DMAYJ5TLIEZ3ZT3PWTDPUOHCGOFY26JAXMOQXE52J2W6D7UA",
+    "content": "gqNzaWfEQMSdIjL5dbUk+/lVCi0AWs84ikMH0gEErgYxuNHpY/dYkKIvY9XlhiszYNMhk2XlkvTCkrrWGOWmblX3Af43tg+jdHhuiaNhbXQBomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKjZ3JwxCBXKHK3sdxBaSQHFwhHjM/4aQktQCY3YfYPkfHTd8BW+qJsds4CAYJQo3JjdsQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKjc25kxCBluk70pvuPX4dYD1Jir85uZP+AImM/8SBmdPRpBSTFAqR0eXBlo3BheQ=="
+  },
+  {
+    "txn_id": "RUU4DMAYJ5TLIEZ3ZT3PWTDPUOHCGOFY26JAXMOQXE52J2W6D7UA",
+    "content": "gqNzaWfEQMSdIjL5dbUk+/lVCi0AWs84ikMH0gEErgYxuNHpY/dYkKIvY9XlhiszYNMhk2XlkvTCkrrWGOWmblX3Af43tg+jdHhuiaNhbXQBomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKjZ3JwxCBXKHK3sdxBaSQHFwhHjM/4aQktQCY3YfYPkfHTd8BW+qJsds4CAYJQo3JjdsQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKjc25kxCBluk70pvuPX4dYD1Jir85uZP+AImM/8SBmdPRpBSTFAqR0eXBlo3BheQ=="
+  }
+]

--- a/tests/tasks/test_sign_transaction.test_sign_from_stdin_with_address_successful.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_sign_from_stdin_with_address_successful.approved.txt
@@ -1,0 +1,29 @@
+Enter the mnemonic phrase (25 words separated by whitespace): 
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 1,
+      "close_remainder_to": null
+    }
+  }
+]
+Would you like to proceed with signing the above? (y, n) [n]: y
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": "gqNzaWfEQHHuPbhkAADyq8eKU/NiDCuJ+cnW9MrHT3iAAEPm+okmoio/rmgctA7QUpqqd4eF5aYlUcgz9EbU+uUXS1rFOg2jdHhuiKNhbXQBomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  }
+]

--- a/tests/tasks/test_sign_transaction.test_sign_from_stdin_with_alias_successful.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_sign_from_stdin_with_alias_successful.approved.txt
@@ -1,0 +1,28 @@
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 1,
+      "close_remainder_to": null
+    }
+  }
+]
+Would you like to proceed with signing the above? (y, n) [n]: y
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": "gqNzaWfEQHHuPbhkAADyq8eKU/NiDCuJ+cnW9MrHT3iAAEPm+okmoio/rmgctA7QUpqqd4eF5aYlUcgz9EbU+uUXS1rFOg2jdHhuiKNhbXQBomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  }
+]

--- a/tests/tasks/test_sign_transaction.test_sign_many_from_file_with_address_successful.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_sign_many_from_file_with_address_successful.approved.txt
@@ -1,0 +1,75 @@
+Enter the mnemonic phrase (25 words separated by whitespace): 
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 1,
+      "close_remainder_to": null
+    }
+  },
+  {
+    "txn_id": "MLS7IUJQVK7GABTCOLTG5QE7NWITX74D6YC3QZLN6Y5SZF23WZBQ",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 2,
+      "close_remainder_to": null
+    }
+  },
+  {
+    "txn_id": "NEI3KU7ALQ6PFOSTYEN3LSJX2CUDEESDH2NH2XUJGYHNR3UVB3OQ",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 3,
+      "close_remainder_to": null
+    }
+  }
+]
+Would you like to proceed with signing the above? (y, n) [n]: y
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": "gqNzaWfEQHHuPbhkAADyq8eKU/NiDCuJ+cnW9MrHT3iAAEPm+okmoio/rmgctA7QUpqqd4eF5aYlUcgz9EbU+uUXS1rFOg2jdHhuiKNhbXQBomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  },
+  {
+    "txn_id": "MLS7IUJQVK7GABTCOLTG5QE7NWITX74D6YC3QZLN6Y5SZF23WZBQ",
+    "content": "gqNzaWfEQMDbNg81bX8hvW+MHye1pJhtDxWvk/3Oec8lC8QZ5i0pn7LNnXTEniYzhECzjwxL11ENlTh6w66M2jl1f4YeZwijdHhuiKNhbXQComZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  },
+  {
+    "txn_id": "NEI3KU7ALQ6PFOSTYEN3LSJX2CUDEESDH2NH2XUJGYHNR3UVB3OQ",
+    "content": "gqNzaWfEQJPaDlnXKBkMacMv6SNJmDlRf2dBzVBZwhOelc/Q+uriONVXzP0pqmZqqCua/fo3DxH9tbKyCDcSYVmn9MsaLgqjdHhuiKNhbXQDomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  }
+]

--- a/tests/tasks/test_sign_transaction.test_sign_many_from_file_with_alias_successful.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_sign_many_from_file_with_alias_successful.approved.txt
@@ -1,0 +1,74 @@
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 1,
+      "close_remainder_to": null
+    }
+  },
+  {
+    "txn_id": "MLS7IUJQVK7GABTCOLTG5QE7NWITX74D6YC3QZLN6Y5SZF23WZBQ",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 2,
+      "close_remainder_to": null
+    }
+  },
+  {
+    "txn_id": "NEI3KU7ALQ6PFOSTYEN3LSJX2CUDEESDH2NH2XUJGYHNR3UVB3OQ",
+    "content": {
+      "sender": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "fee": 0,
+      "first_valid_round": 33652328,
+      "last_valid_round": 33653328,
+      "note": null,
+      "genesis_id": "testnet-v1.0",
+      "genesis_hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "group": null,
+      "lease": null,
+      "type": "pay",
+      "rekey_to": null,
+      "receiver": "MW5E55FG7OHV7B2YB5JGFL6ONZSP7ABCMM77CIDGOT2GSBJEYUBOF3UYKA",
+      "amt": 3,
+      "close_remainder_to": null
+    }
+  }
+]
+Would you like to proceed with signing the above? (y, n) [n]: y
+[
+  {
+    "txn_id": "YGSOMX5QSASQALR5V4MH47L4GEHFJZVGSUETJAWUFM2I6PJAQL4Q",
+    "content": "gqNzaWfEQHHuPbhkAADyq8eKU/NiDCuJ+cnW9MrHT3iAAEPm+okmoio/rmgctA7QUpqqd4eF5aYlUcgz9EbU+uUXS1rFOg2jdHhuiKNhbXQBomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  },
+  {
+    "txn_id": "MLS7IUJQVK7GABTCOLTG5QE7NWITX74D6YC3QZLN6Y5SZF23WZBQ",
+    "content": "gqNzaWfEQMDbNg81bX8hvW+MHye1pJhtDxWvk/3Oec8lC8QZ5i0pn7LNnXTEniYzhECzjwxL11ENlTh6w66M2jl1f4YeZwijdHhuiKNhbXQComZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  },
+  {
+    "txn_id": "NEI3KU7ALQ6PFOSTYEN3LSJX2CUDEESDH2NH2XUJGYHNR3UVB3OQ",
+    "content": "gqNzaWfEQJPaDlnXKBkMacMv6SNJmDlRf2dBzVBZwhOelc/Q+uriONVXzP0pqmZqqCua/fo3DxH9tbKyCDcSYVmn9MsaLgqjdHhuiKNhbXQDomZ2zgIBfmijZ2VurHRlc3RuZXQtdjEuMKJnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAgGCUKNyY3bEIGW6TvSm+49fh1gPUmKvzm5k/4AiYz/xIGZ09GkFJMUCo3NuZMQgZbpO9Kb7j1+HWA9SYq/ObmT/gCJjP/EgZnT0aQUkxQKkdHlwZaNwYXk="
+  }
+]

--- a/tests/tasks/test_sign_transaction.test_transaction_decoding_errors.approved.txt
+++ b/tests/tasks/test_sign_transaction.test_transaction_decoding_errors.approved.txt
@@ -1,0 +1,3 @@
+Enter the mnemonic phrase (25 words separated by whitespace): 
+DEBUG: Invalid base64-encoded string: number of data characters (5) cannot be 1 more than a multiple of 4
+Error: Failed to decode transaction! If you are intending to sign multiple transactions use --file instead.

--- a/tests/tasks/test_transfer.py
+++ b/tests/tasks/test_transfer.py
@@ -78,7 +78,8 @@ def test_transfer_no_amount() -> None:
 def test_transfer_algo_from_address_successful(mocker: MockerFixture) -> None:
     # Arrange
     mocker.patch("algokit.cli.tasks.transfer.transfer_algos", return_value=TransactionMock())
-    mocker.patch("algokit.cli.tasks.transfer._validate_inputs")
+    mocker.patch("algokit.cli.tasks.transfer.validate_address")
+    mocker.patch("algokit.cli.tasks.transfer.validate_balance")
     dummy_sender_pk, dummy_sender_address = _generate_account()
     dummy_receiver_address = _generate_account()[1]
 
@@ -96,7 +97,8 @@ def test_transfer_algo_from_address_successful(mocker: MockerFixture) -> None:
 def test_transfer_algo_from_alias_successful(mocker: MockerFixture, mock_keyring: dict[str, str]) -> None:
     # Arrange
     mocker.patch("algokit.cli.tasks.transfer.transfer_algos", return_value=TransactionMock())
-    mocker.patch("algokit.cli.tasks.transfer._validate_inputs")
+    mocker.patch("algokit.cli.tasks.transfer.validate_address")
+    mocker.patch("algokit.cli.tasks.transfer.validate_balance")
     dummy_sender_pk, dummy_sender_address = _generate_account()
     dummy_receiver_address = _generate_account()[1]
 
@@ -120,7 +122,8 @@ def test_transfer_algo_from_alias_successful(mocker: MockerFixture, mock_keyring
 def test_transfer_asset_from_address_successful(mocker: MockerFixture) -> None:
     # Arrange
     mocker.patch("algokit.cli.tasks.transfer.transfer_asset", return_value=TransactionMock())
-    mocker.patch("algokit.cli.tasks.transfer._validate_inputs")
+    mocker.patch("algokit.cli.tasks.transfer.validate_address")
+    mocker.patch("algokit.cli.tasks.transfer.validate_balance")
     dummy_sender_pk, dummy_sender_address = _generate_account()
     dummy_receiver_address = _generate_account()[1]
 
@@ -138,7 +141,8 @@ def test_transfer_asset_from_address_successful(mocker: MockerFixture) -> None:
 def test_transfer_asset_from_address_to_alias_successful(mocker: MockerFixture, mock_keyring: dict[str, str]) -> None:
     # Arrange
     mocker.patch("algokit.cli.tasks.transfer.transfer_asset", return_value=TransactionMock())
-    mocker.patch("algokit.cli.tasks.transfer._validate_inputs")
+    mocker.patch("algokit.cli.tasks.transfer.validate_address")
+    mocker.patch("algokit.cli.tasks.transfer.validate_balance")
     dummy_sender_pk, dummy_sender_address = _generate_account()
     _generate_account()[1]
 
@@ -162,7 +166,8 @@ def test_transfer_asset_from_address_to_alias_successful(mocker: MockerFixture, 
 def test_transfer_asset_from_alias_successful(mocker: MockerFixture, mock_keyring: dict[str, str]) -> None:
     # Arrange
     mocker.patch("algokit.cli.tasks.transfer.transfer_asset", return_value=TransactionMock())
-    mocker.patch("algokit.cli.tasks.transfer._validate_inputs")
+    mocker.patch("algokit.cli.tasks.transfer.validate_address")
+    mocker.patch("algokit.cli.tasks.transfer.validate_balance")
     dummy_sender_pk, dummy_sender_address = _generate_account()
     dummy_receiver_address = _generate_account()[1]
 
@@ -186,7 +191,8 @@ def test_transfer_asset_from_alias_successful(mocker: MockerFixture, mock_keyrin
 def test_transfer_failed(mocker: MockerFixture, mock_keyring: dict[str, str]) -> None:
     # Arrange
     mocker.patch("algokit.cli.tasks.transfer.transfer_algos", side_effect=Exception("dummy error"))
-    mocker.patch("algokit.cli.tasks.transfer._validate_inputs")
+    mocker.patch("algokit.cli.tasks.transfer.validate_address")
+    mocker.patch("algokit.cli.tasks.transfer.validate_balance")
     dummy_sender_pk, dummy_sender_address = _generate_account()
     dummy_receiver_address = _generate_account()[1]
 


### PR DESCRIPTION
## Proposed changes

- This PR refactors the code by moving some functions from transfer.py to utils.py for better code organization and reusability. It also adds a new feature to sign Algorand transactions in sign_transaction.py.
- Adding `.` at the end of all help messages in tasks for consistency. Updating affected tests, regenerating docs

## TODO

- [x] Snapshot tests

## Open questions

- Acceptance criteria explicitly mentions that this operation allows working with single transaction per file/base64 encoded record passed. @robdmoore just making sure we are on the same page, as you can see in the implementation if user provides a file with more than 1 txn in the file click will raise an exception saying only 1 txn per file is supported for signing
