### PR TITLE
docs: updating docs for the issue on python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ This is an open source project managed by the Algorand Foundation. See the [cont
 ## Prerequisites
 
 The key required dependency is Python 3.10+, but some of the installation options below will install that for you.
-> **Note**
-Due to compatibility issues, we advise using Python versions up to 3.11 for now.
+> **IMPORTANT**  
+> Due to some dependency compatibility issues with Python 3.12, we advise using Python versions up to 3.11 for now.
 
 AlgoKit also has some runtime dependencies that also need to be available for particular commands.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This is an open source project managed by the Algorand Foundation. See the [cont
 ## Prerequisites
 
 The key required dependency is Python 3.10+, but some of the installation options below will install that for you.
+> **Note**
+Due to compatibility issues, we advise using Python versions up to 3.11 for now.
 
 AlgoKit also has some runtime dependencies that also need to be available for particular commands.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This is an open source project managed by the Algorand Foundation. See the [cont
 
 The key required dependency is Python 3.10+, but some of the installation options below will install that for you.
 
-> **🚨IMPORTANT🚨**  
+> **IMPORTANT**  
 > Due to [`aiohttp`](https://github.com/aio-libs/aiohttp/issues/7675) dependency compatibility issues with Python 3.12, we advise using Python versions up to 3.11 for now. This is a temporary measure until stable release of `aiohttp` with 3.12 support is available.
 
 AlgoKit also has some runtime dependencies that also need to be available for particular commands.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ This is an open source project managed by the Algorand Foundation. See the [cont
 ## Prerequisites
 
 The key required dependency is Python 3.10+, but some of the installation options below will install that for you.
-> **IMPORTANT**  
-> Due to some dependency compatibility issues with Python 3.12, we advise using Python versions up to 3.11 for now.
+
+> **🚨IMPORTANT🚨**  
+> Due to [`aiohttp`](https://github.com/aio-libs/aiohttp/issues/7675) dependency compatibility issues with Python 3.12, we advise using Python versions up to 3.11 for now. This is a temporary measure until stable release of `aiohttp` with 3.12 support is available.
 
 AlgoKit also has some runtime dependencies that also need to be available for particular commands.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2893,13 +2893,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.6"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
-    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Proposed Changes

  - Updating docs as an important note to warn users for dependency incompatibility of python 3.12 with installing AlgoKit.

