### PR TITLE
Support codespaces for explore

### DIFF
--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -28,7 +28,7 @@ class NetworkConfiguration(NetworkConfigurationRequired, total=False):
 
 
 GITPOD_URL = os.environ.get("GITPOD_WORKSPACE_URL")
-CODESPAE_NAME = os.environ.get("CODESPACE_NAME")
+CODESPACE_NAME = os.environ.get("CODESPACE_NAME")
 
 if GITPOD_URL:
     algod_url = GITPOD_URL.replace("https://", "https://4001-")
@@ -37,10 +37,10 @@ if GITPOD_URL:
     algod_port = 443
     indexer_port = 443
     kmd_port = 443
-elif CODESPAE_NAME:
-    algod_url = f"https://{CODESPAE_NAME}-4001.app.github.dev"
-    indexer_url = f"https://{CODESPAE_NAME}-8980.app.github.dev"
-    kmd_url = f"https://{CODESPAE_NAME}-4002.app.github.dev"
+elif CODESPACE_NAME:
+    algod_url = f"https://{CODESPACE_NAME}-4001.app.github.dev"
+    indexer_url = f"https://{CODESPACE_NAME}-8980.app.github.dev"
+    kmd_url = f"https://{CODESPACE_NAME}-4002.app.github.dev"
     algod_port = 443
     indexer_port = 443
     kmd_port = 443

--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -28,17 +28,41 @@ class NetworkConfiguration(NetworkConfigurationRequired, total=False):
 
 
 GITPOD_URL = os.environ.get("GITPOD_WORKSPACE_URL")
+CODESPAE_NAME = os.environ.get("CODESPACE_NAME")
+
+if GITPOD_URL:
+    algod_url = GITPOD_URL.replace("https://", "https://4001-")
+    indexer_url = GITPOD_URL.replace("https://", "https://8980-")
+    kmd_url = GITPOD_URL.replace("https://", "https://4002-")
+    algod_port = 443
+    indexer_port = 443
+    kmd_port = 443
+elif CODESPAE_NAME:
+    algod_url = f"https://{CODESPAE_NAME}-4001.app.github.dev"
+    indexer_url = f"https://{CODESPAE_NAME}-8980.app.github.dev"
+    kmd_url = f"https://{CODESPAE_NAME}-4002.app.github.dev"
+    algod_port = 443
+    indexer_port = 443
+    kmd_port = 443
+else:
+    algod_url = DEFAULT_ALGOD_SERVER
+    indexer_url = DEFAULT_ALGOD_SERVER
+    kmd_url = DEFAULT_ALGOD_SERVER
+    algod_port = DEFAULT_ALGOD_PORT
+    indexer_port = DEFAULT_INDEXER_PORT
+    kmd_port = DEFAULT_ALGOD_PORT + 1
+
 NETWORKS: dict[str, NetworkConfiguration] = {
     "localnet": {
-        "algod_url": GITPOD_URL.replace("https://", "https://4001-") if GITPOD_URL else DEFAULT_ALGOD_SERVER,
-        "indexer_url": GITPOD_URL.replace("https://", "https://8980-") if GITPOD_URL else DEFAULT_ALGOD_SERVER,
-        "algod_port": 443 if GITPOD_URL else DEFAULT_ALGOD_PORT,
+        "algod_url": algod_url,
+        "indexer_url": indexer_url,
+        "algod_port": algod_port,
         "algod_token": DEFAULT_ALGOD_TOKEN,
-        "indexer_port": 443 if GITPOD_URL else DEFAULT_INDEXER_PORT,
+        "indexer_port": indexer_port,
         "indexer_token": DEFAULT_ALGOD_TOKEN,
         "kmd_token": DEFAULT_ALGOD_TOKEN,
-        "kmd_port": 443 if GITPOD_URL else DEFAULT_ALGOD_PORT + 1,
-        "kmd_url": GITPOD_URL.replace("https://", "https://4002-") if GITPOD_URL else DEFAULT_ALGOD_SERVER,
+        "kmd_port": kmd_port,
+        "kmd_url": kmd_url,
     },  # TODO: query these instead of using constants
     "testnet": {
         "algod_url": "https://testnet-api.algonode.cloud",


### PR DESCRIPTION
Adds support for GitHub codespaces with algokit explore, similar to how gitpod was supported.

Future work to be done on bootstrap so that it will setup the .env to the proper urls (opposed to localhost) for the frontend. 
