### PR TITLE
fix: correctly convert list of tuple to dictionary

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3356,4 +3356,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "682201e4f76e28eabd67f47af20e176a1e5a9940acd93150b2e1d5ab984effec"
+content-hash = "3529576ad73a5d8e0f1fe7f17dc19a1a7c67901b3948384292e267e3a0a9b7f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ shellingham = "^1.5.0.post1"
 algokit-client-generator = "^1.0.3"
 tomli = { version = "^2.0.1", python = "<3.11" }
 python-dotenv = "^1.0.0"
-# workaround for issue with copier dependency spec allowing major upgrade to pydantic v2
 pydantic = "^2.4.0"
 mslex = "^1.1.0"
 keyring = "^24.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ shellingham = "^1.5.0.post1"
 algokit-client-generator = "^1.0.3"
 tomli = { version = "^2.0.1", python = "<3.11" }
 python-dotenv = "^1.0.0"
-pydantic = "^2.4.0"
 mslex = "^1.1.0"
 keyring = "^24.2.0"
 pyjwt = "^2.8.0"

--- a/src/algokit/cli/generate.py
+++ b/src/algokit/cli/generate.py
@@ -43,14 +43,16 @@ def _load_custom_generate_commands(project_dir: Path) -> dict[str, click.Command
             type=click.Path(exists=True),
             default=generator.path,
         )
-        def command(answers: dict, path: Path) -> None:
+        def command(answers: list[tuple[str, str]], path: Path) -> None:
             if not shutil.which("git"):
                 raise click.ClickException(
                     "Git not found; please install git and add to path.\n"
                     "See https://github.com/git-guides/install-git for more information."
                 )
 
-            return run_generator(answers, path)
+            answers_dict = dict(answers)
+
+            return run_generator(answers_dict, path)
 
         commands_table[generator.name] = command
 


### PR DESCRIPTION
Fixes #352

This error started occurring when updating to the latest copier, which also required an update to pydantic. It appears pydantic no longer is ok with passing a List of Tuple, where a dictionary is required.

## Proposed Changes
  - Correctly type and convert the `list[tuple[str, str]]` to a `dict[str,str]` which fixes the pydantic error.