### PR TITLE
fix: adding confirmation prompt prior to execution of algokit generators

### DIFF
--- a/src/algokit/cli/generate.py
+++ b/src/algokit/cli/generate.py
@@ -52,6 +52,14 @@ def _load_custom_generate_commands(project_dir: Path) -> dict[str, click.Command
 
             answers_dict = dict(answers)
 
+            if not click.confirm(
+                "You are about to run a generator. Please make sure it's from a "
+                "trusted source (for example, official AlgoKit Templates). Do you want to proceed?",
+                default=False,
+            ):
+                logger.warning("Generator execution cancelled.")
+                return None
+
             return run_generator(answers_dict, path)
 
         commands_table[generator.name] = command

--- a/src/algokit/core/generate.py
+++ b/src/algokit/core/generate.py
@@ -44,6 +44,7 @@ def run_generator(answers: dict, path: Path) -> None:
         dst_path=cwd,
         data=answers,
         quiet=True,
+        unsafe=True,
     ) as copier_worker:
         logger.debug(f"Running generator in {copier_worker.src_path}")
         copier_worker.run_copy()

--- a/tests/generate/test_generate_custom_generate_commands.py
+++ b/tests/generate/test_generate_custom_generate_commands.py
@@ -113,7 +113,7 @@ path = "{smart_contract_path}"
     mock_copier_worker_cls = mocker.patch("copier.main.Worker")
     mock_copier_worker_cls.return_value.__enter__.return_value.src_path = str(cwd / "smart_contract")
 
-    result = invoke("generate smart-contract", cwd=cwd)
+    result = invoke("generate smart-contract", cwd=cwd, input="y\n")
 
     assert result.exit_code == 0
     assert mock_copier_worker_cls.call_args.kwargs["src_path"] == str(cwd / "smart_contract")

--- a/tests/generate/test_generate_custom_generate_commands.test_generate_custom_generate_commands_valid_generator_run.approved.txt
+++ b/tests/generate/test_generate_custom_generate_commands.test_generate_custom_generate_commands_valid_generator_run.approved.txt
@@ -1,2 +1,3 @@
 DEBUG: Attempting to load project config from {current_working_directory}/.algokit.toml
+You are about to run a generator. Please make sure it's from a trusted source (for example, official AlgoKit Templates). Do you want to proceed? [y/N]: y
 DEBUG: Running generator in {current_working_directory}/smart_contract


### PR DESCRIPTION
## Proposed changes

- Enabling untrusted mode when running a copier worker for generators
- Adding a warning prompt prior to execution of a generator to let user be aware that they should verify sources of their generators (unless coming from our official templates) prior to running them. 
- The reason why this wasn't a problem before is due to a typo in our beaker's generator's copier yaml, a follow up PR on beaker template will fix it once its merged. The reason why the trusted flag is needed though is due to the fact that copier won't run a copier yaml with _tasks defined by default, hence we introduce an explicit prompt on algokit side prior to execution. I have considered mechanisms to resolve whether generator is coming from a trusted source or not but its not trivial and can't account for a case where someone just copies a new custom generator into an existing algokit project and runs it -> a force popup that always appears (unless force flag is passed) gives us a way to deal with making sure user is always cautious of custom generators that may come from untrusted third party templates.