### PR TITLE
fix: installation process for tealer (windows compatibility)

### DIFF
--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: "poetry"
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: poetry install --no-interaction && pipx install tealer==0.1.1
 
       - name: pytest + coverage
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ AlgoKit development is done within the [AlgoKit Guiding Principles](./docs/algok
    - Via AlgoKit CLI:
 
      - [Install AlgoKit CLI](./README.md#install) and run `algokit bootstrap poetry` in the root directory
+     - Install `tealer` - by running `pipx install tealer=0.1.1`. This is a prerequisite to running `pytest`, tealer is a third party tool for static analysis of TEAL code, algokit uses it in `task analyse` command. AlgoKit uses `pytest-xdist` to speed up the test suite execution by running tests in parallel, this requires `tealer` to be installed globally to avoid race conditions.
 
 3. Install pre-commit hooks (optional but recommended):
 

--- a/src/algokit/cli/tasks/analyze.py
+++ b/src/algokit/cli/tasks/analyze.py
@@ -11,6 +11,7 @@ from algokit.core.tasks.analyze import (
     generate_summaries,
     generate_tealer_command,
     has_baseline_diff,
+    install_tealer_if_needed,
     load_tealer_report,
     prepare_artifacts_folders,
     run_tealer,
@@ -159,6 +160,9 @@ def analyze(  # noqa: PLR0913, C901
     """
     Analyze TEAL programs for common vulnerabilities using Tealer.
     """
+
+    # Install tealer if needed
+    install_tealer_if_needed()
 
     detectors_to_exclude = sorted(set(detectors_to_exclude))
     input_files = get_input_files(input_paths=input_paths, recursive=recursive)

--- a/tests/tasks/test_analyze.py
+++ b/tests/tasks/test_analyze.py
@@ -31,6 +31,7 @@ def _format_snapshot(output: str, targets: list[str], replacement: str = "dummy"
         r"^(Tealer installed successfully via pipx!).*",
         r"^(DEBUG: Running 'pipx install tealer==0.1.1').*",
         r"^(Tealer not found; attempting to install it...).*",
+        r"^(No such file or directory:).*",
         r"^(DEBUG: Running 'pipx --version' in '{current_working_directory}').*",
     ]
 

--- a/tests/tasks/test_analyze.py
+++ b/tests/tasks/test_analyze.py
@@ -26,8 +26,17 @@ def _format_snapshot(output: str, targets: list[str], replacement: str = "dummy"
         output = output.replace(target, replacement)
 
     # If output contains more than one new line trim them to have at most one whitespace in between
+    patterns_to_remove = [
+        r"^(pipx:|DEBUG: pipx:|DEBUG: tealer).*",
+        r"^(Tealer installed successfully via pipx!).*",
+        r"^(DEBUG: Running 'pipx install tealer==0.1.1').*",
+        r"^(Tealer not found; attempting to install it...).*",
+        r"^(DEBUG: Running 'pipx --version' in '{current_working_directory}').*",
+    ]
 
-    output = re.sub(r"^(pipx:|DEBUG: pipx:).*", "", output, flags=re.MULTILINE)
+    for pattern in patterns_to_remove:
+        output = re.sub(pattern, "", output, flags=re.MULTILINE)
+
     return re.sub(r"\n\s*\n", "\n\n", output)
 
 
@@ -201,7 +210,6 @@ def test_analyze_error_in_tealer(
         verify(result.output)
 
 
-@pytest.mark.usefixtures("generate_report_filename_mock")
 def test_analyze_diff_flag(
     cwd: Path,
 ) -> None:

--- a/tests/tasks/test_analyze.py
+++ b/tests/tasks/test_analyze.py
@@ -1,5 +1,4 @@
 import re
-import subprocess
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -55,11 +54,6 @@ def cwd(tmp_path_factory: pytest.TempPathFactory) -> Generator[Path, None, None]
 def generate_report_filename_mock() -> Generator[MagicMock, None, None]:
     with patch("algokit.cli.tasks.analyze.generate_report_filename", return_value="dummy_report.json") as mock:
         yield mock
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _install_tealer() -> None:
-    subprocess.run(["pipx", "install", "tealer==0.1.1"], check=True)
 
 
 @pytest.mark.usefixtures("generate_report_filename_mock")

--- a/tests/tasks/test_analyze.py
+++ b/tests/tasks/test_analyze.py
@@ -25,7 +25,8 @@ def _format_snapshot(output: str, targets: list[str], replacement: str = "dummy"
     for target in targets:
         output = output.replace(target, replacement)
 
-    # If output contains more than one new line trim them to have at most one whitespace in between
+    # Remove tealer logs specific to fresh install, given that these are running against real
+    # tealer and not the mocked version
     patterns_to_remove = [
         r"^(pipx:|DEBUG: pipx:|DEBUG: tealer).*",
         r"^(Tealer installed successfully via pipx!).*",

--- a/tests/tasks/test_analyze.test_analyze_abort_disclaimer.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_abort_disclaimer.approved.txt
@@ -1,2 +1,4 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: n
 Aborted!

--- a/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
@@ -1,7 +1,7 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-Running 'tealer --json {current_working_directory}/dummy.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
+Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"
-tealer: json output is written to {current_working_directory}/dummy.json
-ERROR: Diff detected in {current_working_directory}/dummy.teal! Please check the content of the snapshot report {current_working_directory}/dummy.json against the latest received report at {current_working_directory}/dummy.received.json.
+tealer: json output is written to {current_working_directory}/dummy_report.json
+ERROR: Diff detected in {current_working_directory}/dummy.teal! Please check the content of the snapshot report {current_working_directory}/dummy_report.json against the latest received report at {current_working_directory}/dummy_report.received.json.

--- a/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
@@ -1,7 +1,7 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
+Running 'tealer --json {current_working_directory}/dummy.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"
-tealer: json output is written to {current_working_directory}/dummy_report.json
-ERROR: Diff detected in {current_working_directory}/dummy.teal! Please check the content of the snapshot report {current_working_directory}/dummy_report.json against the latest received report at {current_working_directory}/dummy_report.received.json.
+tealer: json output is written to {current_working_directory}/dummy.json
+ERROR: Diff detected in {current_working_directory}/dummy.teal! Please check the content of the snapshot report {current_working_directory}/dummy.json against the latest received report at {current_working_directory}/dummy.received.json.

--- a/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
@@ -1,6 +1,7 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
-
+Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_report.json
 ERROR: Diff detected in {current_working_directory}/dummy.teal! Please check the content of the snapshot report {current_working_directory}/dummy_report.json against the latest received report at {current_working_directory}/dummy_report.received.json.

--- a/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Unable to provide the diff since {current_working_directory}/dummy.teal report is missing. Please run the task without the --diff flag first.

--- a/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Unable to provide the diff since {current_working_directory}/dummy.teal report is missing. Please run the task without the --diff flag first.

--- a/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
@@ -1,4 +1,4 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
 Unable to provide the diff since {current_working_directory}/dummy.teal report is missing. Please run the task without the --diff flag first.

--- a/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 An error occurred while analyzing {current_working_directory}/dummy.teal. Please make sure the files supplied are valid TEAL code before trying again.
 Aborted!

--- a/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 An error occurred while analyzing {current_working_directory}/dummy.teal. Please make sure the files supplied are valid TEAL code before trying again.
 Aborted!

--- a/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
@@ -1,7 +1,5 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
-
 An error occurred while analyzing {current_working_directory}/dummy.teal. Please make sure the files supplied are valid TEAL code before trying again.
 Aborted!

--- a/tests/tasks/test_analyze.test_analyze_error_no_pipx.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_error_no_pipx.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
 DEBUG: No such file or directory: tealer
-Tealer not found; attempting to install it...
+
 Error: Unable to find pipx install so that `tealer` static analyzer can be installed; please install pipx via https://pypa.github.io/pipx/ and then try `algokit task analyze ...` again.

--- a/tests/tasks/test_analyze.test_analyze_error_no_pipx.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_error_no_pipx.approved.txt
@@ -1,2 +1,4 @@
-Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: No such file or directory: tealer
+Tealer not found; attempting to install it...
 Error: Unable to find pipx install so that `tealer` static analyzer can be installed; please install pipx via https://pypa.github.io/pipx/ and then try `algokit task analyze ...` again.

--- a/tests/tasks/test_analyze.test_analyze_error_no_pipx.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_error_no_pipx.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
 DEBUG: No such file or directory: tealer
-
+Tealer not found; attempting to install it...
 Error: Unable to find pipx install so that `tealer` static analyzer can be installed; please install pipx via https://pypa.github.io/pipx/ and then try `algokit task analyze ...` again.

--- a/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
@@ -1,23 +1,21 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_0.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_0.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_1.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_1.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_2.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_2.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_3.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_3.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_4.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_4.teal' in '{current_working_directory}'
+Running 'tealer --json {current_working_directory}/dummy_0.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_0.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_0.teal"
+tealer: json output is written to {current_working_directory}/dummy_0.teal
+Running 'tealer --json {current_working_directory}/dummy_1.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_1.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_1.teal"
+tealer: json output is written to {current_working_directory}/dummy_1.teal
+Running 'tealer --json {current_working_directory}/dummy_2.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_2.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_2.teal"
+tealer: json output is written to {current_working_directory}/dummy_2.teal
+Running 'tealer --json {current_working_directory}/dummy_3.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_3.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_3.teal"
+tealer: json output is written to {current_working_directory}/dummy_3.teal
+Running 'tealer --json {current_working_directory}/dummy_4.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_4.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_4.teal"
+tealer: json output is written to {current_working_directory}/dummy_4.teal
 
 File: dummy_0.teal
 

--- a/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_0.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_0.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_0.teal"

--- a/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_0.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_0.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_0.teal"

--- a/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_0/dummy.teal"

--- a/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_0/dummy.teal"

--- a/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
@@ -1,23 +1,21 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_contracts/subfolder_1/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_1/dummy.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_contracts/subfolder_2/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_2/dummy.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_contracts/subfolder_3/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_3/dummy.teal' in '{current_working_directory}'
-
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_contracts/subfolder_4/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_4/dummy.teal' in '{current_working_directory}'
+Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_0/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal
+Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_1/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_1/dummy.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_1/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_contracts/subfolder_1/dummy.teal
+Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_2/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_2/dummy.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_2/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_contracts/subfolder_2/dummy.teal
+Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_3/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_3/dummy.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_3/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_contracts/subfolder_3/dummy.teal
+Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_4/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_4/dummy.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_4/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_contracts/subfolder_4/dummy.teal
 
 File:  4_dummy.teal
 

--- a/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"

--- a/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"

--- a/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
@@ -1,7 +1,9 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
+Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_report.json
 
 File: dummy_report.json
 

--- a/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
@@ -1,2 +1,4 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Warning: Skipping {current_working_directory}/dummy.teal due to template variables. Substitute them before scanning.

--- a/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Warning: Skipping {current_working_directory}/dummy.teal due to template variables. Substitute them before scanning.

--- a/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Warning: Skipping {current_working_directory}/dummy.teal due to template variables. Substitute them before scanning.

--- a/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
+++ b/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
@@ -1,5 +1,6 @@
+DEBUG: Running 'tealer --version' in '{current_working_directory}'
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
-DEBUG: Running 'pipx --version' in '{current_working_directory}'
-
-Running 'pipx run --spec tealer==0.1.1 tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal --exclude is-deletable, missing-fee-check, rekey-to' in '{current_working_directory}'
-
+Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal --exclude is-deletable, missing-fee-check, rekey-to' in '{current_working_directory}'
+tealer: Reading contract from file: "{current_working_directory}/dummy.teal"
+tealer: json output is written to {current_working_directory}/dummy_report.json

--- a/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
+++ b/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-
+DEBUG: tealer: 0.1.1
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal --exclude is-deletable, missing-fee-check, rekey-to' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"

--- a/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
+++ b/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal --exclude is-deletable, missing-fee-check, rekey-to' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"


### PR DESCRIPTION
# Proposed changes

- Fixes compatibility with windows and aligns installation process for tealer to match the approach with poetry installation in bootstrap 
- since pytest is run via `pytest-xdist` in order to avoid race conditions on initial install of tealer, contributing docs and pipeline are updated to install tealer prior to execution of the pytest suite.