### PR TITLE
chore: pinning tealer to 3.12 compatible version from pypi

### DIFF
--- a/.github/actions/setup-poetry/action.yaml
+++ b/.github/actions/setup-poetry/action.yaml
@@ -20,3 +20,14 @@ runs:
       run: |
         pipx install poetry==${{ inputs.poetry-version }}
       shell: bash
+
+    - name: Get full Python version
+      id: full-python-version
+      shell: bash
+      run: echo "full_version=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')" >> $GITHUB_OUTPUT
+
+    - name: Setup poetry cache
+      uses: actions/cache@v4
+      with:
+        path: ./.venv
+        key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-${{ steps.full-python-version.outputs.full_version }}

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -37,12 +37,6 @@ jobs:
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
 
-      - name: Setup poetry cache
-        uses: actions/cache@v4
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-${{ inputs.python_version }}
-
       - name: Install dependencies
         run: poetry install --no-interaction
 

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -22,12 +22,6 @@ jobs:
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
 
-      - uses: actions/cache@v4
-        name: Setup poetry cache
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}-${{ matrix.os }}-${{ matrix.python }}
-
       - name: Install dependencies
         # TODO: remove fixed pipx dependency once 3.12 compatibility is addressed
         # track here -> https://github.com/crytic/tealer/pull/209

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         # TODO: remove fixed pipx dependency once 3.12 compatibility is addressed
         # track here -> https://github.com/crytic/tealer/pull/209
-        run: poetry install --no-interaction && pipx install git+https://github.com/algorandfoundation/tealer@3-12
+        run: poetry install --no-interaction && pipx install tealer==0.1.2
 
       - name: pytest + coverage
         shell: bash

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,12 +46,6 @@ jobs:
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
 
-      - uses: actions/cache@v4
-        name: Setup poetry cache
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-3.10
-
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 

--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -18,12 +18,6 @@ jobs:
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
 
-      - uses: actions/cache@v4
-        name: Setup poetry cache
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-3.12
-
       - name: Install dependencies
         run: poetry install --no-interaction
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ AlgoKit development is done within the [AlgoKit Guiding Principles](./docs/algok
    - Via AlgoKit CLI:
 
      - [Install AlgoKit CLI](./README.md#install) and run `algokit bootstrap poetry` in the root directory
-     - Install `tealer` - by running `pipx install git+https://github.com/algorandfoundation/tealer@3-12`. This is a prerequisite to running `pytest`, tealer is a third party tool for static analysis of TEAL code, algokit uses it in `task analyse` command. AlgoKit uses `pytest-xdist` to speed up the test suite execution by running tests in parallel, this requires `tealer` to be installed globally to avoid race conditions.
+     - Install `tealer` - by running `pipx install tealer==0.1.2`. This is a prerequisite to running `pytest`, tealer is a third party tool for static analysis of TEAL code, algokit uses it in `task analyse` command. AlgoKit uses `pytest-xdist` to speed up the test suite execution by running tests in parallel, this requires `tealer` to be installed globally to avoid race conditions.
 
 3. Install pre-commit hooks (optional but recommended):
 

--- a/src/algokit/core/tasks/analyze.py
+++ b/src/algokit/core/tasks/analyze.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 TEALER_REPORTS_ROOT = Path.cwd() / ".algokit/static-analysis"
 TEALER_SNAPSHOTS_ROOT = TEALER_REPORTS_ROOT / "snapshots"
 TEALER_DOT_FILES_ROOT = TEALER_REPORTS_ROOT / "tealer"
-TEALER_VERSION = "0.1.1"
-TEALER_FORK = "git+https://github.com/algorandfoundation/tealer@3-12"
+TEALER_VERSION = "0.1.2"
 
 
 class TealerBlock(BaseModel):
@@ -104,7 +103,7 @@ def install_tealer_if_needed() -> None:
             "and then try `algokit task analyze ...` again."
         )
         run(
-            [*pipx_command, "install", f"{TEALER_FORK}"],
+            [*pipx_command, "install", f"tealer=={TEALER_VERSION}"],
             bad_return_code_error_message=(
                 "Unable to install tealer via pipx; please install tealer "
                 "manually and try `algokit task analyze ...` again."

--- a/tests/tasks/test_analyze.test_analyze_abort_disclaimer.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_abort_disclaimer.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: n
 Aborted!

--- a/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"

--- a/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_diff_flag_missing_old_report.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Unable to provide the diff since {current_working_directory}/dummy.teal report is missing. Please run the task without the --diff flag first.

--- a/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_error_in_tealer.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 An error occurred while analyzing {current_working_directory}/dummy.teal. Please make sure the files supplied are valid TEAL code before trying again.
 Aborted!

--- a/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_0.teal detect --contracts {current_working_directory}/dummy_contracts/dummy_0.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/dummy_0.teal"

--- a/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_multiple_files_recursive.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal detect --contracts {current_working_directory}/dummy_contracts/subfolder_0/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy_contracts/subfolder_0/dummy.teal"

--- a/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_single_file.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"

--- a/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
+++ b/tests/tasks/test_analyze.test_analyze_skipping_tmpl_vars.approved.txt
@@ -1,4 +1,4 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Warning: Skipping {current_working_directory}/dummy.teal due to template variables. Substitute them before scanning.

--- a/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
+++ b/tests/tasks/test_analyze.test_exclude_vulnerabilities.approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Running 'tealer --version' in '{current_working_directory}'
-DEBUG: tealer: 0.1.1
+DEBUG: tealer: 0.1.2
 Warning: This task uses `tealer` to suggest improvements for your TEAL programs, but remember to always test your smart contracts code, follow modern software engineering practices and use the guidelines for smart contract development. This should not be used as a substitute for an actual audit. Do you understand? [Y/n]: y
 Running 'tealer --json {current_working_directory}/dummy_report.json detect --contracts {current_working_directory}/dummy.teal --exclude is-deletable, missing-fee-check, rekey-to' in '{current_working_directory}'
 tealer: Reading contract from file: "{current_working_directory}/dummy.teal"


### PR DESCRIPTION
Fixes https://github.com/algorandfoundation/algokit-cli/issues/414

## Proposed Changes

  - Pinning tealer to fixed official version served from pypi 
  - Extra minor improvements in `cache` step that takes patch version into account. 

