### PR TITLE
chore: build binary for Apple Silicon

### DIFF
--- a/.github/actions/build-binaries/action.yaml
+++ b/.github/actions/build-binaries/action.yaml
@@ -10,6 +10,9 @@ inputs:
   operating_system:
     description: "Operating system to set the correct binary path and extension"
     required: true
+  architecture:
+    description: "Architecture to set the correct binary path and extension"
+    required: true
   build_command:
     description: "Command to build the binaries"
     required: true
@@ -54,9 +57,9 @@ runs:
         ls -l dist
         cd dist/algokit/
         if [ "${{ inputs.production_release }}" == "true" ]; then
-          tar -zcvf ../../algokit-${{ env.RELEASE_VERSION }}-${{ inputs.operating_system }}-py${{ inputs.python_version }}.tar.gz *
+          tar -zcvf ../../algokit-${{ env.RELEASE_VERSION }}-${{ inputs.operating_system }}-${{ inputs.architecture }}-py${{ inputs.python_version }}.tar.gz *
         else
-          tar -zcvf ../../algokit-${{ inputs.operating_system }}-py${{ inputs.python_version }}.tar.gz *
+          tar -zcvf ../../algokit-${{ inputs.operating_system }}-${{ inputs.architecture }}-py${{ inputs.python_version }}.tar.gz *
         fi
         cd ../..
         ls -l
@@ -65,15 +68,15 @@ runs:
       if: ${{ inputs.production_release == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: algokit-${{ inputs.operating_system }}-py${{ inputs.python_version }}
-        path: algokit-${{ env.RELEASE_VERSION }}-${{ inputs.operating_system }}-py${{ inputs.python_version }}.tar.gz
+        name: algokit-${{ inputs.operating_system }}-${{ inputs.architecture }}-py${{ inputs.python_version }}
+        path: algokit-${{ env.RELEASE_VERSION }}-${{ inputs.operating_system }}-${{ inputs.architecture }}-py${{ inputs.python_version }}.tar.gz
 
     - name: Upload binary as artifact (dev)
       if: ${{ inputs.production_release != 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: algokit-${{ inputs.operating_system }}-py${{ inputs.python_version }}
-        path: algokit-${{ inputs.operating_system }}-py${{ inputs.python_version }}.tar.gz
+        name: algokit-${{ inputs.operating_system }}-${{ inputs.architecture }}-py${{ inputs.python_version }}
+        path: algokit-${{ inputs.operating_system }}-${{ inputs.architecture }}-py${{ inputs.python_version }}.tar.gz
 
     - name: Append binary to release
       continue-on-error: true
@@ -81,6 +84,6 @@ runs:
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          algokit-${{ env.RELEASE_VERSION }}-${{ inputs.operating_system }}-py${{ inputs.python_version }}.tar.gz
+          algokit-${{ env.RELEASE_VERSION }}-${{ inputs.operating_system }}-${{ inputs.architecture }}-py${{ inputs.python_version }}.tar.gz
         tag_name: ${{ env.RELEASE_VERSION }}
         prerelease: ${{ contains(env.RELEASE_VERSION, 'beta') }}

--- a/.github/actions/setup-poetry/action.yaml
+++ b/.github/actions/setup-poetry/action.yaml
@@ -1,20 +1,21 @@
 name: "Python Poetry Action"
 description: "An action to setup Poetry"
-inputs:
-  poetry-version:
-    description: "The version of poetry to install"
-    required: false
-    default: "latest"
 runs:
   using: "composite"
   steps:
-    - if: ${{ inputs.poetry-version == 'latest' }}
+    # A workaround for pipx isn't installed on M1 runner.
+    # We should remove it after this issue is resolved.
+    # https://github.com/actions/runner-images/issues/9256
+    - if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
       run: |
         pip install poetry
       shell: bash
-    - if: ${{ inputs.poetry-version != 'latest' }}
+
+    - if: ${{ runner.os != 'macOS' || runner.arch != 'ARM64' }}
       run: |
-        pip install poetry==${{ inputs.poetry-version }}
+        pip install --user pipx
+        pipx ensurepath
+        pipx install poetry
       shell: bash
 
     - name: Get full Python version
@@ -26,4 +27,4 @@ runs:
       uses: actions/cache@v4
       with:
         path: ./.venv
-        key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-${{ steps.full-python-version.outputs.full_version }}
+        key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.full-python-version.outputs.full_version }}

--- a/.github/actions/setup-poetry/action.yaml
+++ b/.github/actions/setup-poetry/action.yaml
@@ -8,17 +8,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        pip install --user pipx
-        pipx ensurepath
-      shell: bash
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
-        pipx install poetry
+        pip install poetry
       shell: bash
     - if: ${{ inputs.poetry-version != 'latest' }}
       run: |
-        pipx install poetry==${{ inputs.poetry-version }}
+        pip install poetry==${{ inputs.poetry-version }}
       shell: bash
 
     - name: Get full Python version

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -40,12 +40,6 @@ jobs:
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
 
-      - name: Setup poetry cache
-        uses: actions/cache@v4
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python_version }}
-
       - name: Install dependencies
         run: poetry install --no-interaction
 

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -15,13 +15,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
         include:
           - os: ubuntu-latest
             build_command: "poetry run poe package_unix"
           - os: windows-latest
             build_command: "poetry run poe package_windows"
           - os: macos-latest
+            build_command: "poetry run poe package_unix"
+          - os: macos-14
             build_command: "poetry run poe package_unix"
     steps:
       - name: Checkout source code
@@ -37,6 +39,12 @@ jobs:
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
 
+      - name: Setup poetry cache
+        uses: actions/cache@v4
+        with:
+          path: ./.venv
+          key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python_version }}
+
       - name: Install dependencies
         run: poetry install --no-interaction
 
@@ -47,4 +55,5 @@ jobs:
           package_name: "algokit"
           production_release: ${{ inputs.production_release }}
           operating_system: ${{ runner.os }}
+          architecture: ${{ runner.arch }}
           build_command: ${{ matrix.build_command }}

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # macos-14 is the Apple Silicon M1 runner
         os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        # Mac and Windows chew through build minutes - waiting until repo is public to enable
         python: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -119,11 +119,11 @@ jobs:
     with:
       production_release: "true"
       python_version: "3.12"
+    secrets: inherit
 
   cd-publish-release-packages:
     name: Publish Release Packages
-    needs: release
-    # if: ${{ github.ref_name == 'chocolatey-package' }} && inputs.production_release != 'true' # used to test manual release from a branch
+    needs: upload-binaries
     if: ${{ github.ref_name == 'main' && inputs.production_release == 'true' }} # Might want to adjust this to publish (pre-release) on merge as well.
     uses: ./.github/workflows/publish-release-packages.yaml
     with:


### PR DESCRIPTION
Fixes #389 

## Proposed Changes

  - Include the process architecture into the output binary.
  - Install `poetry` directly with `pip`.
  - Build an extra binary for Apple Silicon.
