### PR TITLE
build: pin to ubuntu 20.04 for better compatibility

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         # macos-14 is the Apple Silicon M1 runner
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+        os: [ubuntu-20.04, windows-latest, macos-latest, macos-14]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             build_command: "poetry run poe package_unix"
           - os: windows-latest
             build_command: "poetry run poe package_windows"


### PR DESCRIPTION
# Overview

Codespaces are still running Ubuntu 20.04 and failing to run the new binaries. This pins the *nix builds to 20.04 which should be forwards compatible with GLIBC. On a unrelated note, the binaries are working great so far everywhere elese! Great work, really excited for them!


### Codespace Error:
```
npx algokit
[10828] Error loading Python lib '/workspaces/algokit-nestjs-template/node_modules/@algokit/cli/bin/_internal/libpython3.12.so.1.0': dlopen: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /workspaces/algokit-nestjs-template/node_modules/@algokit/cli/bin/_internal/libpython3.12.so.1.0)
```

### Details

I started messing around with wrapping the binaries in a light wrapper in `nodejs` and creating a very basic PoC with a template. The template works in CodeSpaces using my cli fork pinned to 20.04.

**Template**: https://github.com/awesome-algorand/algokit-nestjs-template
**Nodejs Wrapper**: https://github.com/awesome-algorand/npm-algokit-cli/blob/main/bin/algokit.js

## Proposed Changes

  - pin binary releases runner to ubuntu 20.04