### PR TITLE
fix: algod container proper SIGTERM handling

### DIFF
--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -401,6 +401,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json

--- a/src/algokit/core/utils.py
+++ b/src/algokit/core/utils.py
@@ -39,8 +39,8 @@ def is_network_available(host: str = "8.8.8.8", port: int = 53, timeout: float =
 
     try:
         socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
-        return True
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
     except OSError:
         return False
 

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
@@ -43,6 +43,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
@@ -35,6 +35,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json

--- a/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
@@ -41,6 +41,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
@@ -41,6 +41,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
@@ -40,6 +40,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
@@ -44,6 +44,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json

--- a/tests/localnet/test_sandbox.test_get_docker_compose_yml.approved.txt
+++ b/tests/localnet/test_sandbox.test_get_docker_compose_yml.approved.txt
@@ -15,6 +15,7 @@ services:
       TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ADMIN_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       GOSSIP_PORT: 10000
+    init: true
     volumes:
       - type: bind
         source: ./algod_config.json


### PR DESCRIPTION
Refined implementation of the contribution from https://github.com/algorandfoundation/algokit-cli/pull/434

## Proposed Changes

  - Sets init: true under algod container to ensure graceful shutdown of both instances of algod running inside single container. 
  
## Further notes

Benchmark of the command with and without init in algod, adding it to other containers is not needed as it's specifically and issue in algod container. 

| Metric      | localnet stop without init    |  localnet stop with init    |
|-------------|----------|----------|
| Time (abs)  | 15.259 s | 5.253 s  |
| User Time   | 0.538 s  | 0.531 s  |
| System Time | 0.178 s  | 0.169 s  |

Containers tested locally against utils and generators, no side effects found affecting tests. 

## TODO

- [x] Retest utils/generators on CI on github actions