### PR TITLE
docs: update named localnet documents on config file locations

### DIFF
--- a/docs/features/localnet.md
+++ b/docs/features/localnet.md
@@ -65,6 +65,18 @@ When you want more control, named LocalNet instances can be used by running `alg
 Once you have a named LocalNet running, the AlgoKit LocalNet commands will target this instance.
 If at any point you'd like to switch back to the default LocalNet, simply run `algokit localnet start`.
 
+### Named LocalNet Configuration Directory
+
+Upon running `algokit localnet start --name {name}`, AlgoKit stores configuration files in a specific folder on your system. The location of this folder depends on your operating system:
+
+- **Windows**: The configuration files are stored in the `APPDATA` folder. 
+- **Linux or Mac**: The configuration files are stored in the `XDG_CONFIG_HOME` directory if it is set. If `XDG_CONFIG_HOME` is not set, the default location is `~/.config`.
+
+Inside the designated configuration folder, you will find a folder named `algokit` which contains the default sandbox hosting default configuration settings. Additionally, you will find folders named `sandbox{custom-name}` for each named LocalNet instance you have created. These folders contain the specific configuration settings for the respective named LocalNet instances.
+
+It is important to note that the configuration files are stored in a way that ensures separation between the default LocalNet environment and any named LocalNet environments you may create. This allows for more control and customization of your development environments.
+
+
 ### Stopping and Resetting the LocalNet
 
 To stop the LocalNet you can execute `algokit localnet stop`. This will turn off the containers, but keep them ready to be started again in the same state by executing `algokit localnet start`.

--- a/docs/features/localnet.md
+++ b/docs/features/localnet.md
@@ -67,7 +67,7 @@ If at any point you'd like to switch back to the default LocalNet, simply run `a
 
 ### Named LocalNet Configuration Directory
 
-When running `algokit localnet start --name {name}`, AlgoKit stores configuration files in a specific folder on your system. The location of this folder depends on your operating system:
+When running `algokit localnet start --name {name}`, AlgoKit stores configuration files in a specific directory on your system. The location of this directory depends on your operating system:
 
 - **Windows**: We use the value of the `APPDATA` environment variable to determine the directory to store the configuration files. This is usually `C:\Users\USERNAME\AppData\Roaming`.
 - **Linux or Mac**: We use the value of the `XDG_CONFIG_HOME` environment variable to determine the directory to store the configuration files. If `XDG_CONFIG_HOME` is not set, the default location is `~/.config`.

--- a/docs/features/localnet.md
+++ b/docs/features/localnet.md
@@ -67,12 +67,12 @@ If at any point you'd like to switch back to the default LocalNet, simply run `a
 
 ### Named LocalNet Configuration Directory
 
-Upon running `algokit localnet start --name {name}`, AlgoKit stores configuration files in a specific folder on your system. The location of this folder depends on your operating system:
+With running `algokit localnet start --name {name}`, AlgoKit stores configuration files in a specific folder on your system. The location of this folder depends on your operating system:
 
 - **Windows**: The configuration files are stored in the `APPDATA` folder. 
 - **Linux or Mac**: The configuration files are stored in the `XDG_CONFIG_HOME` directory if it is set. If `XDG_CONFIG_HOME` is not set, the default location is `~/.config`.
 
-Inside the designated configuration folder, you will find a folder named `algokit` which contains the default sandbox hosting default configuration settings. Additionally, you will find folders named `sandbox_{name}` for each named LocalNet instance you have created. These folders contain the specific configuration settings for the respective named LocalNet instances.
+Inside the designated configuration folder, you will find a folder named `algokit`. Within the `algokit` folder, there is a `sandbox` directory that contains the default configuration settings. Additionally, for each named LocalNet instance you have created, there will be a folder named `sandbox_{name}` within the `algokit` directory. These folders contain the specific configuration settings for the respective named LocalNet instances.
 
 It is important to note that the configuration files are stored in a way that ensures separation between the default LocalNet environment and any named LocalNet environments you may create. This allows for more control and customization of your development environments.
 

--- a/docs/features/localnet.md
+++ b/docs/features/localnet.md
@@ -72,7 +72,7 @@ Upon running `algokit localnet start --name {name}`, AlgoKit stores configuratio
 - **Windows**: The configuration files are stored in the `APPDATA` folder. 
 - **Linux or Mac**: The configuration files are stored in the `XDG_CONFIG_HOME` directory if it is set. If `XDG_CONFIG_HOME` is not set, the default location is `~/.config`.
 
-Inside the designated configuration folder, you will find a folder named `algokit` which contains the default sandbox hosting default configuration settings. Additionally, you will find folders named `sandbox{custom-name}` for each named LocalNet instance you have created. These folders contain the specific configuration settings for the respective named LocalNet instances.
+Inside the designated configuration folder, you will find a folder named `algokit` which contains the default sandbox hosting default configuration settings. Additionally, you will find folders named `sandbox_{name}` for each named LocalNet instance you have created. These folders contain the specific configuration settings for the respective named LocalNet instances.
 
 It is important to note that the configuration files are stored in a way that ensures separation between the default LocalNet environment and any named LocalNet environments you may create. This allows for more control and customization of your development environments.
 

--- a/docs/features/localnet.md
+++ b/docs/features/localnet.md
@@ -67,14 +67,14 @@ If at any point you'd like to switch back to the default LocalNet, simply run `a
 
 ### Named LocalNet Configuration Directory
 
-With running `algokit localnet start --name {name}`, AlgoKit stores configuration files in a specific folder on your system. The location of this folder depends on your operating system:
+When running `algokit localnet start --name {name}`, AlgoKit stores configuration files in a specific folder on your system. The location of this folder depends on your operating system:
 
-- **Windows**: The configuration files are stored in the `APPDATA` folder. 
-- **Linux or Mac**: The configuration files are stored in the `XDG_CONFIG_HOME` directory if it is set. If `XDG_CONFIG_HOME` is not set, the default location is `~/.config`.
+- **Windows**: We use the value of the `APPDATA` environment variable to determine the directory to store the configuration files. This is usually `C:\Users\USERNAME\AppData\Roaming`.
+- **Linux or Mac**: We use the value of the `XDG_CONFIG_HOME` environment variable to determine the directory to store the configuration files. If `XDG_CONFIG_HOME` is not set, the default location is `~/.config`.
 
-Inside the designated configuration folder, you will find a folder named `algokit`. Within the `algokit` folder, there is a `sandbox` directory that contains the default configuration settings. Additionally, for each named LocalNet instance you have created, there will be a folder named `sandbox_{name}` within the `algokit` directory. These folders contain the specific configuration settings for the respective named LocalNet instances.
+Assuming you have previously used a default LocalNet, the path `./algokit/sandbox/` will exist inside the configuration directory, containing the configuration settings for the default LocalNet instance. Additionally, for each named LocalNet instance you have created, the path `./algokit/sandbox_{name}/` will exist, containing the configuration settings for the respective named LocalNet instances.
 
-It is important to note that the configuration files are stored in a way that ensures separation between the default LocalNet environment and any named LocalNet environments you may create. This allows for more control and customization of your development environments.
+It is important to note that only the configuration files for a named LocalNet instance should be changed. Any changes made to the default LocalNet instance will be reverted by AlgoKit.
 
 
 ### Stopping and Resetting the LocalNet


### PR DESCRIPTION
Fixes #443

## Proposed Changes

  - Updating docs to provide detailed information on the storage location of configuration files for named LocalNet instances.