### PR TITLE
feat: LocalNet should run as an archival node so that you can access all blocks

### DIFF
--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -255,7 +255,7 @@ def _wait_for_algod() -> bool:
 def get_config_json() -> str:
     return (
         '{ "Version": 12, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:8080", "DNSBootstrapID": "",'
-        ' "IncomingConnectionsLimit": 0, "Archival":false, "isIndexerActive":false, "EnableDeveloperAPI":true}'
+        ' "IncomingConnectionsLimit": 0, "Archival":true, "isIndexerActive":false, "EnableDeveloperAPI":true}'
     )
 
 

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
@@ -89,4 +89,4 @@ services:
       - conduit
 
 {app_config}/sandbox/algod_config.json
-{ "Version": 12, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:8080", "DNSBootstrapID": "", "IncomingConnectionsLimit": 0, "Archival":false, "isIndexerActive":false, "EnableDeveloperAPI":true}
+{ "Version": 12, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:8080", "DNSBootstrapID": "", "IncomingConnectionsLimit": 0, "Archival":true, "isIndexerActive":false, "EnableDeveloperAPI":true}

--- a/tests/localnet/test_sandbox.test_get_config_json.approved.txt
+++ b/tests/localnet/test_sandbox.test_get_config_json.approved.txt
@@ -4,7 +4,7 @@
   "EndpointAddress": "0.0.0.0:8080",
   "DNSBootstrapID": "",
   "IncomingConnectionsLimit": 0,
-  "Archival": false,
+  "Archival": true,
   "isIndexerActive": false,
   "EnableDeveloperAPI": true
 }


### PR DESCRIPTION
This is useful when testing.

For example, the algokit-subscriber-ts library needs to go back to block 1 and once you've been running localnet for a while and get past 1000 blocks this test now fails.

This wasn't the previous behaviour (not being archival), but I believe [this change](https://github.com/algorand/go-algorand/releases/tag/v3.22.0-stable) may have caused a change (although it's weird we had `Archival: false` and it was an archival node previously.