### PR TITLE
chore: lockfile maintenance; bumping copier version; setting up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      all:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/poetry.lock
+++ b/poetry.lock
@@ -569,21 +569,20 @@ files = [
 
 [[package]]
 name = "copier"
-version = "9.0.1"
+version = "9.2.0"
 description = "A library for rendering project templates."
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = ">=3.8"
 files = [
-    {file = "copier-9.0.1-py3-none-any.whl", hash = "sha256:0c5d0a0de372e1b0cb9f0f19988fadf6f652a5df78931ef5e9206b27fab8766e"},
-    {file = "copier-9.0.1.tar.gz", hash = "sha256:eaf525bbccad7acc66fb11ff52f1a96bf32b2470389d3c077c21e339b755842e"},
+    {file = "copier-9.2.0-py3-none-any.whl", hash = "sha256:62682ce8cd78db1006feafe2c815d59d5069efa4c2009017f3c63780d977f6de"},
+    {file = "copier-9.2.0.tar.gz", hash = "sha256:4ed9012579923955d3fc61d049568907fabe6d9a47e5f871236c6aae0b7472f1"},
 ]
 
 [package.dependencies]
-colorama = ">=0.4.3"
-decorator = ">=5.1.1"
-dunamai = ">=1.7.0"
+colorama = ">=0.4.6"
+dunamai = {version = ">=1.7.0", markers = "python_version < \"4\""}
 funcy = ">=1.17"
-jinja2 = ">=3.1.1"
+jinja2 = ">=3.1.3"
 jinja2-ansible-filters = ">=1.3.1"
 packaging = ">=23.0"
 pathspec = ">=0.9.0"
@@ -591,7 +590,6 @@ plumbum = ">=1.6.9"
 pydantic = ">=2.4.2"
 pygments = ">=2.7.1"
 pyyaml = ">=5.3.1"
-pyyaml-include = ">=1.2"
 questionary = ">=1.8.1"
 
 [[package]]
@@ -730,17 +728,6 @@ files = [
 packageurl-python = ">=0.11"
 py-serializable = ">=0.11.1,<0.12.0"
 sortedcontainers = ">=2.4.0,<3.0.0"
-
-[[package]]
-name = "decorator"
-version = "5.1.1"
-description = "Decorators for Humans"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
-    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
-]
 
 [[package]]
 name = "defusedxml"
@@ -2564,6 +2551,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2597,23 +2585,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
 ]
-
-[[package]]
-name = "pyyaml-include"
-version = "1.4.1"
-description = "Extending PyYAML with a custom constructor for including YAML files within YAML files"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471"},
-    {file = "pyyaml_include-1.4.1-py3-none-any.whl", hash = "sha256:323c7f3a19c82fbc4d73abbaab7ef4f793e146a13383866831631b26ccc7fb00"},
-]
-
-[package.dependencies]
-PyYAML = ">=6.0,<7.0"
-
-[package.extras]
-toml = ["toml"]
 
 [[package]]
 name = "questionary"
@@ -3443,4 +3414,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "32c8ff2c1732ef62868c35faa7f7cc59293b322b46653b6d8ce6fae971955b35"
+content-hash = "8ffed99092c2f219618e625b085bf5985b9663855d5bfc87fbdfdc2e9e246cb5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = ">=3.10,<3.13"
 click = "^8.1.3"
 httpx = "^0.23.1"
-copier = "^9.0.0"
+copier = "^9.2.0"
 questionary = "^1.10.0"
 pyclip = "^0.7.0"
 shellingham = "^1.5.0.post1"
@@ -25,8 +25,6 @@ multiformats = "0.3.1"
 multiformats_config = "0.3.1" # pinned this to be in lockstep with multiformats
 aiohttp = "3.9.3"
 jsondiff = "^2.0.0"
-# Pinning to fix copier transitive dependency, remove this once https://github.com/copier-org/copier/issues/1568 is fixed.
-pyyaml-include = "1.4.1"
 
 [tool.poetry.group.dev.dependencies]
 pyinstaller = {version = "^6.3.0"}

--- a/src/algokit/cli/init.py
+++ b/src/algokit/cli/init.py
@@ -357,7 +357,7 @@ def init_command(  # noqa: PLR0913, C901, PLR0915
     # 2. the import fails if git is not installed (which we check above)
     # TODO: copier is typed, need to figure out how to force mypy to accept that or submit a PR
     #       to their repo to include py.typed file
-    from copier.main import Worker  # type: ignore[import]
+    from copier.main import Worker
 
     from algokit.core.init import populate_default_answers
 
@@ -518,7 +518,7 @@ def _fail_and_bail() -> NoReturn:
 
 def _repo_url_is_valid(url: str) -> bool:
     """Check the repo URL is valid according to copier"""
-    from copier.vcs import get_repo  # type: ignore[import]
+    from copier.vcs import get_repo
 
     if not url:
         return False

--- a/src/algokit/core/generate.py
+++ b/src/algokit/core/generate.py
@@ -46,7 +46,7 @@ def run_generator(answers: dict, path: Path) -> None:
     # copier is lazy imported for two reasons
     # 1. it is slow to import on first execution after installing
     # 2. the import fails if git is not installed (which we check above)
-    from copier.main import Worker  # type: ignore[import]
+    from copier.main import Worker
 
     cwd = Path.cwd()
     with Worker(

--- a/src/algokit/core/init.py
+++ b/src/algokit/core/init.py
@@ -5,7 +5,9 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, cast
 
-from copier.main import MISSING, AnswersMap, Question, Worker  # type: ignore[import]
+from copier.main import Worker
+from copier.types import MISSING
+from copier.user_data import AnswersMap, Question
 
 from algokit.core.project import get_project_dir_names_from_workspace
 


### PR DESCRIPTION
## Proposed Changes

This initially started as an attempt to fix the pkgutil.ImpImporter issue reported by @joe-p , however dissecting the lockfiles for versions v1.11.4 (anything from that version or lower does not throw the impimporter error) vs any version starting from v1.12.x (that throws the impimporter runtime error) -> it became very non trivial and took many hours to investigate. Unfortunately updating the lockfile and removing the redundant transient dependency to fix old copier issues was not enough to address the impImporter and the actual root cause there seems to be related to either pip or pipx itself (for reference, latest pip v24 came out 2 weeks ago and utils-py had no pipelines run from main for a month so its entirely possible this impimporter issue has been there for a weeks). 

On the other hand i think these changes are still useful to propagate. I added dependabot settings to automate version bumps and potentially letting us action on transient dependency issues faster. Also, removed a redundant transitive dependency related to copier, with copier itself being bumped to a more stable version. A few copier related imports no longer require typing ignore comments for pylance/mypy after bumping to latest versions - i presume copier fixed typing related issues at this point (or perhaps its the minor bump in mypy itself)