### PR TITLE
fix: ensure utf-8 is used as part of cli animate method invocation (windows compatibility)

### DIFF
--- a/src/algokit/__main__.py
+++ b/src/algokit/__main__.py
@@ -1,9 +1,7 @@
 from multiprocessing import freeze_support
 
 from algokit.cli import algokit
-from algokit.core.utils import enable_utf8_on_windows
 
 # Required to support full feature parity when running in binary execution mode
 freeze_support()
-enable_utf8_on_windows()
 algokit()

--- a/src/algokit/__main__.py
+++ b/src/algokit/__main__.py
@@ -1,7 +1,9 @@
 from multiprocessing import freeze_support
 
 from algokit.cli import algokit
+from algokit.core.utils import enable_utf8_on_windows
 
 # Required to support full feature parity when running in binary execution mode
 freeze_support()
+enable_utf8_on_windows()
 algokit()

--- a/src/algokit/core/utils.py
+++ b/src/algokit/core/utils.py
@@ -264,3 +264,8 @@ def alphanumeric_sort_key(s: str) -> list[int | str]:
     For instance, ensures that "name_digit_1" comes before "name_digit_2".
     """
     return [int(text) if text.isdigit() else text.lower() for text in re.split("([0-9]+)", s)]
+
+
+def enable_utf8_on_windows() -> None:
+    if is_windows():
+        os.environ["PYTHONUTF8"] = "1"

--- a/src/algokit/core/utils.py
+++ b/src/algokit/core/utils.py
@@ -53,6 +53,9 @@ def is_network_available(host: str = "8.8.8.8", port: int = 53, timeout: float =
 
 def animate(name: str, stop_event: threading.Event) -> None:
     """Displays an animated spinner in the console."""
+    # Ensure sys.stdout uses UTF-8 encoding
+    if sys.stdout.encoding.lower() != "utf-8":
+        sys.stdout = open(sys.stdout.fileno(), mode="w", encoding="utf-8", buffering=1)  # noqa: SIM115, PTH123
 
     for frame in cycle(SPINNER_FRAMES):
         if stop_event.is_set():
@@ -264,8 +267,3 @@ def alphanumeric_sort_key(s: str) -> list[int | str]:
     For instance, ensures that "name_digit_1" comes before "name_digit_2".
     """
     return [int(text) if text.isdigit() else text.lower() for text in re.split("([0-9]+)", s)]
-
-
-def enable_utf8_on_windows() -> None:
-    if is_windows():
-        os.environ["PYTHONUTF8"] = "1"


### PR DESCRIPTION
The animate method in cli was causing unicode errors on windows similar to bug with writes in separate repo that were recently fixed in https://github.com/algorandfoundation/algokit-client-generator-py/pull/27. Adding a check to ensure utf-8 is used