### PR TITLE
fix: add localnet proxy to add Access-Control-Allow-Private-Network header

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1519,6 +1519,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -2603,7 +2604,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3180,13 +3180,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.1"
+version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
-    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
+    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
+    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
 ]
 
 [package.extras]

--- a/tests/goal/test_goal.py
+++ b/tests/goal/test_goal.py
@@ -3,7 +3,13 @@ from pathlib import Path
 from subprocess import CompletedProcess
 
 import pytest
-from algokit.core.sandbox import ALGOD_HEALTH_URL, get_algod_network_template, get_config_json, get_docker_compose_yml
+from algokit.core.sandbox import (
+    ALGOD_HEALTH_URL,
+    get_algod_network_template,
+    get_config_json,
+    get_docker_compose_yml,
+    get_proxy_config,
+)
 from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
 
@@ -43,6 +49,7 @@ def _setup_latest_dummy_compose(app_dir_mock: AppDirs) -> None:
     (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").write_text(get_docker_compose_yml())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_config.json").write_text(get_config_json())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_network_template.json").write_text(get_algod_network_template())
+    (app_dir_mock.app_config_dir / "sandbox" / "nginx.conf").write_text(get_proxy_config())
 
 
 @pytest.fixture()

--- a/tests/localnet/test_localnet_console.py
+++ b/tests/localnet/test_localnet_console.py
@@ -2,7 +2,7 @@ import json
 from subprocess import CompletedProcess
 
 import pytest
-from algokit.core.sandbox import get_algod_network_template, get_config_json, get_docker_compose_yml
+from algokit.core.sandbox import get_algod_network_template, get_config_json, get_docker_compose_yml, get_proxy_config
 from pytest_mock import MockerFixture
 
 from tests.goal.test_goal import _normalize_output
@@ -25,6 +25,7 @@ def test_goal_console(
     (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").write_text(get_docker_compose_yml())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_config.json").write_text(get_config_json())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_network_template.json").write_text(get_algod_network_template())
+    (app_dir_mock.app_config_dir / "sandbox" / "nginx.conf").write_text(get_proxy_config())
 
     mocker.patch("algokit.core.proc.subprocess_run").return_value = CompletedProcess(
         ["docker", "exec"], 0, "STDOUT+STDERR"

--- a/tests/localnet/test_localnet_reset.py
+++ b/tests/localnet/test_localnet_reset.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from algokit.core.sandbox import get_algod_network_template, get_config_json, get_docker_compose_yml
+from algokit.core.sandbox import get_algod_network_template, get_config_json, get_docker_compose_yml, get_proxy_config
 
 from tests import get_combined_verify_output
 from tests.utils.app_dir_mock import AppDirs
@@ -52,6 +52,7 @@ def test_localnet_reset_with_existing_sandbox_with_up_to_date_config(app_dir_moc
     (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").write_text(get_docker_compose_yml())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_config.json").write_text(get_config_json())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_network_template.json").write_text(get_algod_network_template())
+    (app_dir_mock.app_config_dir / "sandbox" / "nginx.conf").write_text(get_proxy_config())
 
     result = invoke("localnet reset")
 
@@ -83,6 +84,7 @@ def test_localnet_reset_with_named_sandbox_config(app_dir_mock: AppDirs, proc_mo
     (app_dir_mock.app_config_dir / "sandbox_test" / "algod_network_template.json").write_text(
         get_algod_network_template()
     )
+    (app_dir_mock.app_config_dir / "sandbox_test" / "nginx.conf").write_text(get_proxy_config())
 
     result = invoke("localnet reset")
 
@@ -98,6 +100,7 @@ def test_localnet_reset_with_existing_sandbox_with_up_to_date_config_with_pull(a
     (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").write_text(get_docker_compose_yml())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_config.json").write_text(get_config_json())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_network_template.json").write_text(get_algod_network_template())
+    (app_dir_mock.app_config_dir / "sandbox" / "nginx.conf").write_text(get_proxy_config())
 
     result = invoke("localnet reset --update")
 

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
@@ -33,8 +33,8 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
-      - 4001:8080
-      - 4002:7833
+      - 8080
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1
@@ -79,13 +79,29 @@ services:
     container_name: "algokit_sandbox_indexer"
     image: algorand/indexer:latest
     ports:
-      - "8980:8980"
+      - 8980
     restart: unless-stopped
     command: daemon --enable-all-parameters
     environment:
       INDEXER_POSTGRES_CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexerdb sslmode=disable"
     depends_on:
       - conduit
+
+  proxy:
+    container_name: "algokit_sandbox_proxy"
+    image: nginx:1.27.0-alpine
+    restart: unless-stopped
+    ports:
+      - 4001:4001
+      - 4002:4002
+      - 8980:8980
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/nginx.conf
+    depends_on:
+      - algod
+      - indexer
 
 {app_config}/sandbox/algod_config.json
 { "Version": 12, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:8080", "DNSBootstrapID": "", "IncomingConnectionsLimit": 0, "Archival":true, "isIndexerActive":false, "EnableDeveloperAPI":true}

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
@@ -25,8 +25,8 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
-      - 4001:8080
-      - 4002:7833
+      - 8080
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1
@@ -71,10 +71,26 @@ services:
     container_name: "algokit_sandbox_indexer"
     image: algorand/indexer:latest
     ports:
-      - "8980:8980"
+      - 8980
     restart: unless-stopped
     command: daemon --enable-all-parameters
     environment:
       INDEXER_POSTGRES_CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexerdb sslmode=disable"
     depends_on:
       - conduit
+
+  proxy:
+    container_name: "algokit_sandbox_proxy"
+    image: nginx:1.27.0-alpine
+    restart: unless-stopped
+    ports:
+      - 4001:4001
+      - 4002:4002
+      - 8980:8980
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/nginx.conf
+    depends_on:
+      - algod
+      - indexer

--- a/tests/localnet/test_localnet_start.py
+++ b/tests/localnet/test_localnet_start.py
@@ -9,6 +9,7 @@ from algokit.core.sandbox import (
     get_algod_network_template,
     get_config_json,
     get_docker_compose_yml,
+    get_proxy_config,
 )
 from pytest_httpx import HTTPXMock
 
@@ -142,6 +143,7 @@ def test_localnet_start_up_to_date_definition(app_dir_mock: AppDirs) -> None:
     (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").write_text(get_docker_compose_yml())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_config.json").write_text(get_config_json())
     (app_dir_mock.app_config_dir / "sandbox" / "algod_network_template.json").write_text(get_algod_network_template())
+    (app_dir_mock.app_config_dir / "sandbox" / "nginx.conf").write_text(get_proxy_config())
 
     result = invoke("localnet start")
 

--- a/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
@@ -31,8 +31,8 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
-      - 4001:8080
-      - 4002:7833
+      - 8080
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1
@@ -77,10 +77,26 @@ services:
     container_name: "algokit_sandbox_indexer"
     image: algorand/indexer:latest
     ports:
-      - "8980:8980"
+      - 8980
     restart: unless-stopped
     command: daemon --enable-all-parameters
     environment:
       INDEXER_POSTGRES_CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexerdb sslmode=disable"
     depends_on:
       - conduit
+
+  proxy:
+    container_name: "algokit_sandbox_proxy"
+    image: nginx:1.27.0-alpine
+    restart: unless-stopped
+    ports:
+      - 4001:4001
+      - 4002:4002
+      - 8980:8980
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/nginx.conf
+    depends_on:
+      - algod
+      - indexer

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
@@ -31,8 +31,8 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
-      - 4001:8080
-      - 4002:7833
+      - 8080
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1
@@ -77,10 +77,26 @@ services:
     container_name: "algokit_sandbox_indexer"
     image: algorand/indexer:latest
     ports:
-      - "8980:8980"
+      - 8980
     restart: unless-stopped
     command: daemon --enable-all-parameters
     environment:
       INDEXER_POSTGRES_CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexerdb sslmode=disable"
     depends_on:
       - conduit
+
+  proxy:
+    container_name: "algokit_sandbox_proxy"
+    image: nginx:1.27.0-alpine
+    restart: unless-stopped
+    ports:
+      - 4001:4001
+      - 4002:4002
+      - 8980:8980
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/nginx.conf
+    depends_on:
+      - algod
+      - indexer

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
@@ -30,8 +30,8 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
-      - 4001:8080
-      - 4002:7833
+      - 8080
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1
@@ -76,10 +76,26 @@ services:
     container_name: "algokit_sandbox_indexer"
     image: algorand/indexer:latest
     ports:
-      - "8980:8980"
+      - 8980
     restart: unless-stopped
     command: daemon --enable-all-parameters
     environment:
       INDEXER_POSTGRES_CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexerdb sslmode=disable"
     depends_on:
       - conduit
+
+  proxy:
+    container_name: "algokit_sandbox_proxy"
+    image: nginx:1.27.0-alpine
+    restart: unless-stopped
+    ports:
+      - 4001:4001
+      - 4002:4002
+      - 8980:8980
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/nginx.conf
+    depends_on:
+      - algod
+      - indexer

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
@@ -34,8 +34,8 @@ services:
     container_name: "algokit_sandbox_test_algod"
     image: algorand/algod:latest
     ports:
-      - 4001:8080
-      - 4002:7833
+      - 8080
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1
@@ -80,10 +80,26 @@ services:
     container_name: "algokit_sandbox_test_indexer"
     image: algorand/indexer:latest
     ports:
-      - "8980:8980"
+      - 8980
     restart: unless-stopped
     command: daemon --enable-all-parameters
     environment:
       INDEXER_POSTGRES_CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexerdb sslmode=disable"
     depends_on:
       - conduit
+
+  proxy:
+    container_name: "algokit_sandbox_test_proxy"
+    image: nginx:1.27.0-alpine
+    restart: unless-stopped
+    ports:
+      - 4001:4001
+      - 4002:4002
+      - 8980:8980
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/nginx.conf
+    depends_on:
+      - algod
+      - indexer

--- a/tests/localnet/test_sandbox.py
+++ b/tests/localnet/test_sandbox.py
@@ -1,6 +1,12 @@
 import json
 
-from algokit.core.sandbox import get_algod_network_template, get_conduit_yaml, get_config_json, get_docker_compose_yml
+from algokit.core.sandbox import (
+    get_algod_network_template,
+    get_conduit_yaml,
+    get_config_json,
+    get_docker_compose_yml,
+    get_proxy_config,
+)
 
 from tests.utils.approvals import verify
 
@@ -23,3 +29,8 @@ def test_get_docker_compose_yml() -> None:
 def test_algod_network_template_json() -> None:
     algod_network_template_json = get_algod_network_template()
     verify(algod_network_template_json)
+
+
+def test_proxy_config() -> None:
+    proxy_config = get_proxy_config()
+    verify(proxy_config)

--- a/tests/localnet/test_sandbox.test_get_docker_compose_yml.approved.txt
+++ b/tests/localnet/test_sandbox.test_get_docker_compose_yml.approved.txt
@@ -5,8 +5,8 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
-      - 4001:8080
-      - 4002:7833
+      - 8080
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1
@@ -51,10 +51,26 @@ services:
     container_name: "algokit_sandbox_indexer"
     image: algorand/indexer:latest
     ports:
-      - "8980:8980"
+      - 8980
     restart: unless-stopped
     command: daemon --enable-all-parameters
     environment:
       INDEXER_POSTGRES_CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexerdb sslmode=disable"
     depends_on:
       - conduit
+
+  proxy:
+    container_name: "algokit_sandbox_proxy"
+    image: nginx:1.27.0-alpine
+    restart: unless-stopped
+    ports:
+      - 4001:4001
+      - 4002:4002
+      - 8980:8980
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/nginx.conf
+    depends_on:
+      - algod
+      - indexer

--- a/tests/localnet/test_sandbox.test_proxy_config.approved.txt
+++ b/tests/localnet/test_sandbox.test_proxy_config.approved.txt
@@ -1,0 +1,65 @@
+worker_processes 1;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  access_log off;
+
+  map $request_method$http_access_control_request_private_network $cors_allow_private_network {
+    "OPTIONStrue" "true";
+    default "";
+  }
+
+  add_header Access-Control-Allow-Private-Network $cors_allow_private_network;
+
+  upstream algod_api {
+    zone upstreams 64K;
+    server algod:8080 max_fails=1 fail_timeout=2s;
+    keepalive 2;
+  }
+
+  upstream kmd_api {
+    zone upstreams 64K;
+    server algod:7833 max_fails=1 fail_timeout=2s;
+    keepalive 2;
+  }
+
+  upstream indexer_api {
+    zone upstreams 64K;
+    server indexer:8980 max_fails=1 fail_timeout=2s;
+    keepalive 2;
+  }
+
+  server {
+    listen 4001;
+
+    location / {
+      proxy_set_header Host $host;
+      proxy_pass http://algod_api;
+      proxy_pass_header Server;
+    }
+  }
+
+  server {
+    listen 4002;
+
+    location / {
+      proxy_set_header Host $host;
+      proxy_pass http://kmd_api;
+      proxy_pass_header Server;
+    }
+  }
+
+  server {
+    listen 8980;
+
+    location / {
+      proxy_set_header Host $host;
+      proxy_pass http://indexer_api;
+      proxy_pass_header Server;
+    }
+  }
+}
+    


### PR DESCRIPTION
Google Chrome is slowly introducing more restrictions on sites which make calls to private network resources.
See https://developer.chrome.com/blog/private-network-access-preflight

This impacts tools like Dappflow.
This PR adds a proxy container to LocalNet and attaches the correct headers to ensure the pre flight CORS request that Chrome sends will succeed.

This PR fixes #524