### PR TITLE
fix: some localnet proxy tweaks

### DIFF
--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -457,7 +457,10 @@ http {{
     listen {algod_port};
 
     location / {{
+      proxy_http_version 1.1;
+      proxy_read_timeout 120s;
       proxy_set_header Host $host;
+      proxy_set_header Connection "";
       proxy_pass_header Server;
       set $target http://algod:8080;
       proxy_pass $target;
@@ -468,7 +471,9 @@ http {{
     listen {kmd_port};
 
     location / {{
+      proxy_http_version 1.1;
       proxy_set_header Host $host;
+      proxy_set_header Connection "";
       proxy_pass_header Server;
       set $target http://algod:7833;
       proxy_pass $target;
@@ -479,7 +484,9 @@ http {{
     listen 8980;
 
     location / {{
+      proxy_http_version 1.1;
       proxy_set_header Host $host;
+      proxy_set_header Connection "";
       proxy_pass_header Server;
       set $target http://indexer:8980;
       proxy_pass $target;
@@ -502,6 +509,7 @@ services:
     container_name: "{name}_algod"
     image: {ALGORAND_IMAGE}
     ports:
+      - 7833
       - {tealdbg_port}:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
@@ -33,6 +33,7 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
@@ -25,6 +25,7 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
@@ -31,6 +31,7 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
@@ -31,6 +31,7 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
@@ -30,6 +30,7 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
@@ -34,6 +34,7 @@ services:
     container_name: "algokit_sandbox_test_algod"
     image: algorand/algod:latest
     ports:
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_sandbox.test_get_docker_compose_yml.approved.txt
+++ b/tests/localnet/test_sandbox.test_get_docker_compose_yml.approved.txt
@@ -5,6 +5,7 @@ services:
     container_name: "algokit_sandbox_algod"
     image: algorand/algod:latest
     ports:
+      - 7833
       - 9392:9392
     environment:
       START_KMD: 1

--- a/tests/localnet/test_sandbox.test_proxy_config.approved.txt
+++ b/tests/localnet/test_sandbox.test_proxy_config.approved.txt
@@ -21,7 +21,10 @@ http {
     listen 4001;
 
     location / {
+      proxy_http_version 1.1;
+      proxy_read_timeout 120s;
       proxy_set_header Host $host;
+      proxy_set_header Connection "";
       proxy_pass_header Server;
       set $target http://algod:8080;
       proxy_pass $target;
@@ -32,7 +35,9 @@ http {
     listen 4002;
 
     location / {
+      proxy_http_version 1.1;
       proxy_set_header Host $host;
+      proxy_set_header Connection "";
       proxy_pass_header Server;
       set $target http://algod:7833;
       proxy_pass $target;
@@ -43,7 +48,9 @@ http {
     listen 8980;
 
     location / {
+      proxy_http_version 1.1;
       proxy_set_header Host $host;
+      proxy_set_header Connection "";
       proxy_pass_header Server;
       set $target http://indexer:8980;
       proxy_pass $target;


### PR DESCRIPTION
A couple of config tweaks to fix some small things I noticed:
- When using the long poll `/v2/status/wait-for-block-after/{round}` endpoint the NGINX proxy upstream timeout can end before the server has responded. The timeout has been increased to ensure that won't happen.
- Sometimes a 502 was returned when calling KMD. Setting the port in the docker compose file fixes this. Both indexer and algod endpoints are fine.
- Tuned config to ensure connections are kept alive.