### PR TITLE
fix: filter null values from asset metadata

### DIFF
--- a/src/algokit/core/tasks/mint/models.py
+++ b/src/algokit/core/tasks/mint/models.py
@@ -66,7 +66,7 @@ class TokenMetadata:
         file_path = Path(tempfile.mkstemp()[1])
         try:
             with file_path.open("w") as file:
-                json.dump(asdict(self), file)
+                file.write(self.to_json(None))
             return file_path
         except FileNotFoundError as err:
             raise ValueError(f"No such file or directory: '{file_path}'") from err


### PR DESCRIPTION
When minting an asset, null values were being added to the asset metadata and should be filtered out.