### PR TITLE
fix: given that .copier-answers.yml is now expected at .algokit folder, improve defaults lookup

### DIFF
--- a/src/algokit/cli/init.py
+++ b/src/algokit/cli/init.py
@@ -361,11 +361,13 @@ def init_command(  # noqa: PLR0913, C901, PLR0915
 
     from algokit.core.init import populate_default_answers
 
-    answers_file = project_path / ".algokit" / ".copier-answers.yml"
+    expected_answers_file = project_path / ".algokit" / ".copier-answers.yml"
+    relative_answers_file = expected_answers_file.relative_to(project_path) if expected_answers_file.exists() else None
+
     with Worker(
         src_path=template.url,
         dst_path=project_path,
-        answers_file=answers_file if answers_file.exists() else None,
+        answers_file=relative_answers_file,
         data=answers_dict,
         quiet=True,
         vcs_ref=template.branch or template.commit,

--- a/src/algokit/core/generate.py
+++ b/src/algokit/core/generate.py
@@ -49,7 +49,11 @@ def run_generator(answers: dict, path: Path) -> None:
     from copier.main import Worker
 
     cwd = Path.cwd()
+    expected_answers_file = cwd / ".algokit" / ".copier-answers.yml"
+    relative_answers_file = expected_answers_file.relative_to(cwd) if expected_answers_file.exists() else None
+
     with Worker(
+        answers_file=relative_answers_file,
         src_path=str(path),
         dst_path=cwd,
         data=answers_dict,


### PR DESCRIPTION
https://github.com/algorandfoundation/algokit-cli/issues/532

## Proposed Changes

  - Adding extra changes to lookup for answers file at .algokit subfolder instead of default copier behaviour that expects it at the root, with these changes we can continue maintaining backwards compatibility with older templates while also support latest convention where .copier-answers is dropped at the .algokit subfolder to reduce clutter of configs at the root
