### PR TITLE
chore: disable any max body size limits in the localnet proxy

### DIFF
--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -447,6 +447,7 @@ http {{
 
   resolver 127.0.0.11 ipv6=off valid=10s;
   resolver_timeout 5s;
+  client_max_body_size 0;
 
   map $request_method$http_access_control_request_private_network $cors_allow_private_network {{
     "OPTIONStrue" "true";

--- a/tests/localnet/test_sandbox.test_proxy_config.approved.txt
+++ b/tests/localnet/test_sandbox.test_proxy_config.approved.txt
@@ -9,6 +9,7 @@ http {
 
   resolver 127.0.0.11 ipv6=off valid=10s;
   resolver_timeout 5s;
+  client_max_body_size 0;
 
   map $request_method$http_access_control_request_private_network $cors_allow_private_network {
     "OPTIONStrue" "true";


### PR DESCRIPTION
Setting `client_max_body_size 0` prevents nginx from returning any 413 error responses.
