### PR TITLE
fix: add warning for cases when explore is used within wsl

### DIFF
--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -1,5 +1,7 @@
+import functools
 import logging
 import os
+import platform
 from typing import TypedDict
 from urllib.parse import urlencode
 
@@ -8,6 +10,21 @@ import click
 from algokit.core.sandbox import DEFAULT_ALGOD_PORT, DEFAULT_ALGOD_SERVER, DEFAULT_ALGOD_TOKEN, DEFAULT_INDEXER_PORT
 
 logger = logging.getLogger(__name__)
+
+
+@functools.cache
+def _is_wsl(v: str = platform.uname().release) -> int:
+    """
+    detects if Python is running in WSL
+    https://github.com/scivision/detect-windows-subsystem-for-linux
+    """
+
+    if v.endswith("-Microsoft"):
+        return 1
+    elif v.endswith("microsoft-standard-WSL2"):
+        return 2
+
+    return 0
 
 
 class NetworkConfigurationRequired(TypedDict):
@@ -98,4 +115,9 @@ def get_explore_url(network: str) -> str:
 def explore_command(network: str) -> None:
     url = get_explore_url(network)
     logger.info(f"Opening {network} explorer in your default browser")
+    if _is_wsl():
+        logger.warning(
+            "WSL detected. Make sure that wslu is installed in order for the cli to open browsers in host OS. "
+            "Installation instructions: https://wslutiliti.es/wslu/install.html"
+        )
     click.launch(url)

--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -117,7 +117,7 @@ def explore_command(network: str) -> None:
     logger.info(f"Opening {network} explorer in your default browser")
     if _is_wsl():
         logger.warning(
-            "WSL detected. Make sure that wslu is installed in order for the cli to open browsers in host OS. "
+            "WSL is detected. Make sure that `wslu` is installed in order for the cli to open a browser url in the host OS. "
             "Installation instructions: https://wslutiliti.es/wslu/install.html"
         )
     click.launch(url)

--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -117,7 +117,7 @@ def explore_command(network: str) -> None:
     logger.info(f"Opening {network} explorer in your default browser")
     if _is_wsl():
         logger.warning(
-            "WSL is detected. Make sure that `wslu` is installed in order for the cli to open a browser url in the host OS. "
+            "WSL is detected. Make sure `wslu` is installed for the CLI to open browsers in host OS. "
             "Installation instructions: https://wslutiliti.es/wslu/install.html"
         )
     click.launch(url)

--- a/src/algokit/core/utils.py
+++ b/src/algokit/core/utils.py
@@ -189,6 +189,14 @@ def is_windows() -> bool:
     return platform.system() == "Windows"
 
 
+def is_wsl() -> bool:
+    """
+    detects if Python is running in WSL
+    https://github.com/scivision/detect-windows-subsystem-for-linux
+    """
+    return platform.uname().release.endswith(("-Microsoft", "microsoft-standard-WSL2"))
+
+
 def split_command_string(command: str) -> list[str]:
     """
     Parses a command string into a list of arguments, handling both shell and non-shell commands


### PR DESCRIPTION
## Proposed Changes

  - A warning to instruct on how to use explore command within wsl - to be removed once the following is addressed https://github.com/python/cpython/issues/89752. Reported by @CiottiGiorgio 