### PR TITLE
fix: build binaries with the correct version information

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -9,6 +9,9 @@ on:
       python_version:
         required: true
         type: string
+      release_version:
+        required: false
+        type: string
 
 jobs:
   build-binaries:
@@ -24,7 +27,8 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ inputs.production_release == 'true' && '0' || '1' }}
+          ref: ${{ inputs.release_version != '' && format('v{0}', inputs.release_version) || '' }}
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,23 +41,12 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction
 
-      - name: Set release version
-        shell: bash
-        continue-on-error: true
-        if: ${{ inputs.production_release == 'true' }}
-        run: |
-          echo "RELEASE_VERSION_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
-
       - name: Configure build environment
         shell: bash
         run: |
           artifacts_dir="${{ github.workspace }}${{ runner.os == 'Windows' && '\dist\artifacts' || '/dist/artifacts' }}"
           mkdir -p $artifacts_dir
-          if [ -n "${RELEASE_VERSION_TAG}" ]; then
-            release_version="${RELEASE_VERSION_TAG:1}"
-            package_name_version="-${release_version}"
-            echo "RELEASE_VERSION=${release_version}" >> $GITHUB_ENV
-          fi
+          package_name_version="${{ inputs.release_version != '' && format('-{0}', inputs.release_version) || '' }}"
           package_name="algokit${package_name_version}-${{ runner.os }}_${{ runner.arch }}"
           echo "PACKAGE_NAME=`echo $package_name | tr '[:upper:]' '[:lower:]'`" >> $GITHUB_ENV
           echo "ARTIFACTS_DIR=${artifacts_dir}" >> $GITHUB_ENV
@@ -64,7 +57,7 @@ jobs:
         uses: ./.github/actions/build-binaries/windows
         with:
           package_name: ${{ env.PACKAGE_NAME }}
-          version: ${{ env.RELEASE_VERSION }}
+          version: ${{ inputs.release_version }}
           artifacts_dir: ${{ env.ARTIFACTS_DIR }}
           production_release: ${{ inputs.production_release }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
@@ -76,7 +69,7 @@ jobs:
         uses: ./.github/actions/build-binaries/linux
         with:
           package_name: ${{ env.PACKAGE_NAME }}
-          version: ${{ env.RELEASE_VERSION }}
+          version: ${{ inputs.release_version }}
           artifacts_dir: ${{ env.ARTIFACTS_DIR }}
 
       - name: Build macOS binary
@@ -84,7 +77,7 @@ jobs:
         uses: ./.github/actions/build-binaries/macos
         with:
           package_name: ${{ env.PACKAGE_NAME }}
-          version: ${{ env.RELEASE_VERSION }}
+          version: ${{ inputs.release_version }}
           artifacts_dir: ${{ env.ARTIFACTS_DIR }}
 
       - name: Add binary to path
@@ -121,5 +114,5 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             ${{ env.ARTIFACTS_DIR }}/*.*
-          tag_name: ${{ env.RELEASE_VERSION_TAG }}
-          prerelease: ${{ contains(env.RELEASE_VERSION_TAG, 'beta') }}
+          tag_name: ${{ format('v{0}', inputs.release_version) }}
+          prerelease: ${{ contains(inputs.release_version, 'beta') }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -36,7 +36,8 @@ jobs:
     name: Release wheels to pypi
     needs: ci-build-python
     runs-on: ubuntu-latest
-
+    outputs:
+      release_version: ${{ steps.get_release_version.outputs.RELEASE_VERSION }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,8 +73,9 @@ jobs:
             --define=prerelease_tag=beta+${{ steps.get_branch.outputs.branch }} \
             --define=branch=${{ steps.get_branch.outputs.branch }} \
             publish
-          gh release edit --prerelease "$(git describe $(git rev-list --tags --max-count=1))"
-        # --define=upload_to_repository=true \
+          release_version_tag="$(git describe $(git rev-list --tags --max-count=1))"
+          gh release edit --prerelease $release_version_tag
+          echo "RELEASE_VERSION=${release_version_tag:1}" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY_USERNAME: __token__
@@ -87,8 +89,9 @@ jobs:
             --prerelease \
             --define=branch=main \
             publish
-          gh release edit --prerelease "v$(poetry run semantic-release print-version --current)"
-        # --define=upload_to_repository=true \
+          release_version="$(poetry run semantic-release print-version --current)"
+          gh release edit --prerelease "v$release_version"
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY_USERNAME: __token__
@@ -104,10 +107,17 @@ jobs:
             --define=upload_to_repository=true \
             --define=branch=main \
             publish
+          release_version="$(poetry run semantic-release print-version --current)"
+          echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY_USERNAME: __token__
           REPOSITORY_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+
+      - name: Get release version
+        shell: bash
+        run: echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+        id: get_release_version
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -122,8 +132,9 @@ jobs:
     uses: ./.github/workflows/build-binaries.yaml
     needs: release
     with:
-      production_release: "true"
+      production_release: ${{ inputs.production_release }}
       python_version: "3.12"
+      release_version: ${{ needs.release.outputs.release_version }}
     secrets: inherit
 
   cd-publish-release-packages:

--- a/scripts/winget/build-installer.ps1
+++ b/scripts/winget/build-installer.ps1
@@ -38,7 +38,7 @@ $version = if ($releaseVersion) {
 else {
   '0.0.1'
 } 
-(Get-Content (Resolve-Path "$installerContentDir\AppxManifest.xml")).Replace('0.0.1.0', $("$version.0")) | Set-Content (Join-Path $buildDir AppxManifest.xml)
+(Get-Content (Resolve-Path "$installerContentDir\AppxManifest.xml")).Replace('"0.0.1.0"', "`"$version.0`"") | Set-Content (Join-Path $buildDir AppxManifest.xml)
 
 # Generate pri resource map for installer assets
 $priConfig = (Resolve-Path "$installerContentDir\priconfig.xml")

--- a/scripts/winget/installer/priconfig.xml
+++ b/scripts/winget/installer/priconfig.xml
@@ -25,8 +25,4 @@
 		<indexer-config type="resjson" initialPath=""/>
 		<indexer-config type="PRI"/>
 	</index>
-	<!--<index startIndexAt="Start Index Here" root="Root Here">-->
-	<!--        <indexer-config type="resfiles" qualifierDelimiter="."/>-->
-	<!--        <indexer-config type="priinfo" emitStrings="true" emitPaths="true" emitEmbeddedData="true"/>-->
-	<!--</index>-->
 </resources>


### PR DESCRIPTION
When building the binaries we were building based on the old version metadata.
This PR fetches the code based on the release tag ref, so that we always build with the correct metadata, as `actions/checkout` will fetch based on the commit hash which triggered the build (not using the main ref), when no ref is supplied.