### PR TITLE
chore: minor patches in brew release pipeline

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,6 +9,12 @@ on:
       - "**.md"
       - ".vscode/**"
       - ".idea/**"
+      - ".gitignore"
+      - ".editorconfig"
+      - ".pre-commit-config.yaml"
+      - ".github/**"
+      - "tests/**"
+      - "scripts/**"
   workflow_dispatch:
     inputs:
       production_release:

--- a/.github/workflows/publish-release-packages.yaml
+++ b/.github/workflows/publish-release-packages.yaml
@@ -60,8 +60,8 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ secrets.ALGOKIT_GH_BOT_ID }}
-          private-key: ${{ secrets.ALGOKIT_GH_BOT_PK }}
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-release-packages.yaml
+++ b/.github/workflows/publish-release-packages.yaml
@@ -61,7 +61,7 @@ jobs:
         id: app-token
         with:
           app-id: ${{ secrets.ALGOKIT_GH_BOT_ID }}
-          private-key: ${{ secrets.ALGOKIT_GH_BOT_SK }}
+          private-key: ${{ secrets.ALGOKIT_GH_BOT_PK }}
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-release-packages.yaml
+++ b/.github/workflows/publish-release-packages.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
+          repositories: algorandfoundation/homebrew-tap
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-release-packages.yaml
+++ b/.github/workflows/publish-release-packages.yaml
@@ -62,7 +62,8 @@ jobs:
         with:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
-          repositories: algorandfoundation/homebrew-tap
+          repositories: homebrew-tap
+          owner: algorandfoundation
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/scripts/update-brew-cask.sh
+++ b/scripts/update-brew-cask.sh
@@ -92,8 +92,10 @@ create_cask() {
 cat << EOF > $cask_file
 cask "$package_name" do
   arch arm: "arm64", intel: "x64"
+  
   version "$version"
-  sha256 arm: "$arm_sha256", intel: "$intel_sha256"
+  sha256 arm:   "$arm_sha256",
+         intel: "$intel_sha256"
 
   url "$repo/releases/download/v#{version}/algokit-#{version}-macos_#{arch}.tar.gz"
   name "$package_name"

--- a/scripts/update-brew-cask.sh
+++ b/scripts/update-brew-cask.sh
@@ -92,7 +92,7 @@ create_cask() {
 cat << EOF > $cask_file
 cask "$package_name" do
   arch arm: "arm64", intel: "x64"
-  
+
   version "$version"
   sha256 arm:   "$arm_sha256",
          intel: "$intel_sha256"

--- a/scripts/update-brew-cask.sh
+++ b/scripts/update-brew-cask.sh
@@ -97,7 +97,7 @@ cask "$package_name" do
   sha256 arm:   "$arm_sha256",
          intel: "$intel_sha256"
 
-  url "$repo/releases/download/v#{version}/algokit-#{version}-macos_#{arch}.tar.gz"
+  url "$repo/releases/download/v#{version}/algokit-#{version}-macos_#{arch}-brew.tar.gz"
   name "$package_name"
   desc "$desc"
   homepage "$homepage"


### PR DESCRIPTION
Fixing typo in env var secret for accessing the gh app for authentication in brew deploy script (previous approach with PAT is no longer viable and deprecated since mid august)