### PR TITLE
fix: explicitly pinning requests dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3143,4 +3143,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "24068d93d54872cea346585eb97ea31c78c0fb909b72f38dfe3a62b9bc66279a"
+content-hash = "7447368b71e89ee380b7c6ee683c6a5f7c972c8a273466aec8c9e153f182c211"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ algokit-utils = "^2.3.0"
 multiformats = "0.3.1"
 multiformats_config = "0.3.1" # pinned this to be in lockstep with multiformats
 jsondiff = "^2.0.0"
+requests = "^2.31.0"
 
 [tool.poetry.group.dev.dependencies]
 pyinstaller = {version = "^6.9.0"}


### PR DESCRIPTION
Hotfix for missing requests dependency (caused by removal of auth0). Requests were part of transitive dependencies in a lockfile so installs in CI passed but a fresh install from a pure wheel was failing. 