### PR TITLE
chore: adding conditional to skip codesigning on PR triggers when building binaries

### DIFF
--- a/.github/actions/build-binaries/macos/action.yaml
+++ b/.github/actions/build-binaries/macos/action.yaml
@@ -9,6 +9,9 @@ inputs:
     required: true
   version:
     description: "The version to use for this artifact"
+  with_codesign:
+    description: "Flag to determine if we should sign the binary"
+    required: true
   apple_team_id:
     description: "The Apple Team ID"
     required: true
@@ -20,10 +23,10 @@ inputs:
     required: true
   apple_notary_user:
     description: "The Apple user to notarise the package"
-    require: true
+    required: true
   apple_notary_password:
     description: "The Apple password to notarise the package"
-    require: true
+    required: true
 
 runs:
   using: "composite"
@@ -31,12 +34,12 @@ runs:
     - name: Build binary
       shell: bash
       run: |
-        export APPLE_CERT_ID="${{ inputs.apple_cert_id }}"
-        export APPLE_BUNDLE_ID="${{ inputs.apple_bundle_id }}"
+        export APPLE_CERT_ID="${{ inputs.with_codesign == 'true' && inputs.apple_cert_id || '' }}"
+        export APPLE_BUNDLE_ID="${{ inputs.with_codesign == 'true' && inputs.apple_bundle_id || format('beta.{0}', inputs.apple_bundle_id) }}"
         poetry run poe package_mac
       env:
-        APPLE_CERT_ID: ${{ inputs.apple_cert_id }}
-        APPLE_BUNDLE_ID: ${{ inputs.apple_bundle_id }}
+        APPLE_CERT_ID: ${{ inputs.with_codesign == 'true' && inputs.apple_cert_id || '' }}
+        APPLE_BUNDLE_ID: ${{ inputs.with_codesign == 'true' && inputs.apple_bundle_id || format('beta.{0}', inputs.apple_bundle_id) }}
 
     - name: Add metadata to binary
       shell: bash
@@ -45,11 +48,13 @@ runs:
 
     # Workaround an issue with PyInstaller where Python.framework was incorrectly signed during the build
     - name: Codesign python.framework
+      if: ${{ inputs.with_codesign == 'true' }}
       shell: bash
       run: |
         codesign --force --sign "${{ inputs.apple_cert_id }}" --timestamp "${{ github.workspace }}/dist/algokit/_internal/Python.framework"
 
     - name: Notarize
+      if: ${{ inputs.with_codesign == 'true' }}
       uses: lando/notarize-action@v2
       with:
         appstore-connect-team-id: ${{ inputs.apple_team_id }}

--- a/.github/actions/build-binaries/windows/action.yaml
+++ b/.github/actions/build-binaries/windows/action.yaml
@@ -9,8 +9,8 @@ inputs:
   artifacts_dir:
     description: "The directory to write artifacts you want to publish"
     required: true
-  production_release:
-    description: "Flag to determine if this is a production release"
+  with_codesign:
+    description: "Flag to determine if we should sign the binary"
     required: true
   azure_tenant_id:
     description: "The Microsoft Entra tenant (directory) ID."
@@ -43,7 +43,7 @@ runs:
         echo winget > '${{ env.BINARY_BUILD_DIR }}\_internal\algokit\resources\distribution-method'
 
     - name: Sign executable
-      if: ${{ inputs.production_release == 'true' }}
+      if: ${{ inputs.with_codesign == 'true' }}
       uses: azure/trusted-signing-action@v0.3.20
       with:
         azure-tenant-id: ${{ inputs.azure_tenant_id }}
@@ -67,7 +67,7 @@ runs:
           -outputFile '${{ env.WINGET_INSTALLER }}'
 
     - name: Sign winget installer
-      if: ${{ inputs.production_release == 'true' }}
+      if: ${{ inputs.with_codesign == 'true' }}
       uses: azure/trusted-signing-action@v0.3.20
       with:
         azure-tenant-id: ${{ inputs.azure_tenant_id }}

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -24,6 +24,21 @@ jobs:
         os: [ubuntu-20.04, windows-latest, macos-13, macos-14]
 
     steps:
+      - name: Set signing condition
+        id: signing
+        run: |
+          # Allow signing on:
+          # 1. Main branch non-PR events when production_release is true OR
+          # 2. Main branch CRON triggered events
+          if [[ "${{ github.event_name }}" != "pull_request" && \
+                "${{ github.ref_name }}" == "main" && \
+                ("${{ inputs.production_release }}" == "true" || "${{ github.event_name }}" == "schedule") ]]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
@@ -58,10 +73,10 @@ jobs:
           package_name: ${{ env.PACKAGE_NAME }}
           version: ${{ inputs.release_version }}
           artifacts_dir: ${{ env.ARTIFACTS_DIR }}
-          production_release: ${{ inputs.production_release }}
-          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          with_codesign: ${{ steps.signing.outputs.allowed }}
+          azure_tenant_id: ${{ steps.signing.outputs.allowed == 'true' && secrets.AZURE_TENANT_ID || '' }}
+          azure_client_id: ${{ steps.signing.outputs.allowed == 'true' && secrets.AZURE_CLIENT_ID || '' }}
+          azure_client_secret: ${{ steps.signing.outputs.allowed == 'true' && secrets.AZURE_CLIENT_SECRET || '' }}
 
       - name: Build linux binary
         if: ${{ runner.os == 'Linux' }}
@@ -72,7 +87,7 @@ jobs:
           artifacts_dir: ${{ env.ARTIFACTS_DIR }}
 
       - name: Install Apple Developer Id Cert
-        if: runner.os == 'macOS'
+        if: ${{ runner.os == 'macOS' && steps.signing.outputs.allowed == 'true' }}
         uses: ./.github/actions/install-apple-dev-id-cert
         with:
           cert_data: ${{ secrets.APPLE_CERT_DATA }}
@@ -85,11 +100,12 @@ jobs:
           package_name: ${{ env.PACKAGE_NAME }}
           version: ${{ inputs.release_version }}
           artifacts_dir: ${{ env.ARTIFACTS_DIR }}
-          apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
+          with_codesign: ${{ steps.signing.outputs.allowed }}
+          apple_team_id: ${{ steps.signing.outputs.allowed == 'true' && secrets.APPLE_TEAM_ID || '' }}
           apple_bundle_id: ${{ inputs.production_release == 'true' && vars.APPLE_BUNDLE_ID || format('beta.{0}', vars.APPLE_BUNDLE_ID) }}
-          apple_cert_id: ${{ secrets.APPLE_CERT_ID }}
-          apple_notary_user: ${{ secrets.APPLE_NOTARY_USER }}
-          apple_notary_password: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          apple_cert_id: ${{ steps.signing.outputs.allowed == 'true' && secrets.APPLE_CERT_ID || '' }}
+          apple_notary_user: ${{ steps.signing.outputs.allowed == 'true' && secrets.APPLE_NOTARY_USER || '' }}
+          apple_notary_password: ${{ steps.signing.outputs.allowed == 'true' && secrets.APPLE_NOTARY_PASSWORD || '' }}
 
       - name: Add binary to path
         run: |

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -27,16 +27,17 @@ jobs:
       - name: Set signing condition
         id: signing
         run: |
-          # Allow signing on:
-          # 1. Main branch non-PR events when production_release is true OR
-          # 2. Main branch CRON triggered events
-          if [[ "${{ github.event_name }}" != "pull_request" && \
-                "${{ github.ref_name }}" == "main" && \
-                ("${{ inputs.production_release }}" == "true" || "${{ github.event_name }}" == "schedule") ]]; then
-            echo "allowed=true" >> $GITHUB_OUTPUT
-          else
-            echo "allowed=false" >> $GITHUB_OUTPUT
-          fi
+          # For testing, force signing to be allowed
+          echo "allowed=true" >> $GITHUB_OUTPUT
+
+          # Comment out or remove the original condition temporarily
+          # if [[ "${{ github.event_name }}" != "pull_request" && \
+          #       "${{ github.ref_name }}" == "main" && \
+          #       ("${{ inputs.production_release }}" == "true" || "${{ github.event_name }}" == "schedule") ]]; then
+          #   echo "allowed=true" >> $GITHUB_OUTPUT
+          # else
+          #   echo "allowed=false" >> $GITHUB_OUTPUT
+          # fi
         shell: bash
 
       - name: Checkout source code

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -27,17 +27,16 @@ jobs:
       - name: Set signing condition
         id: signing
         run: |
-          # For testing, force signing to be allowed
-          echo "allowed=true" >> $GITHUB_OUTPUT
-
-          # Comment out or remove the original condition temporarily
-          # if [[ "${{ github.event_name }}" != "pull_request" && \
-          #       "${{ github.ref_name }}" == "main" && \
-          #       ("${{ inputs.production_release }}" == "true" || "${{ github.event_name }}" == "schedule") ]]; then
-          #   echo "allowed=true" >> $GITHUB_OUTPUT
-          # else
-          #   echo "allowed=false" >> $GITHUB_OUTPUT
-          # fi
+          # Allow signing on:
+          # 1. Main branch non-PR events when production_release is true OR
+          # 2. Main branch CRON triggered events
+          if [[ "${{ github.event_name }}" != "pull_request" && \
+                "${{ github.ref_name }}" == "main" && \
+                ("${{ inputs.production_release }}" == "true" || "${{ github.event_name }}" == "schedule") ]]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+          fi
         shell: bash
 
       - name: Checkout source code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,18 +59,7 @@ docs_title = {shell = "(echo \"# AlgoKit CLI Reference Documentation\\n\\n\"; ca
 docs = ["docs_generate", "docs_toc", "docs_title"]
 package_unix = "pyinstaller --clean --onedir --hidden-import jinja2_ansible_filters --hidden-import multiformats_config --copy-metadata algokit --name algokit --noconfirm src/algokit/__main__.py --add-data './misc/multiformats_config:multiformats_config/' --add-data './src/algokit/resources:algokit/resources/'"
 package_windows = { cmd = "scripts/package_windows.bat" }
-package_mac.shell = """pyinstaller --clean --onedir \
-    --hidden-import jinja2_ansible_filters \
-    --hidden-import multiformats_config \
-    --copy-metadata algokit \
-    --name algokit \
-    --noconfirm src/algokit/__main__.py \
-    --add-data './misc/multiformats_config/multibase-table.json:multiformats_config/' \
-    --add-data './misc/multiformats_config/multicodec-table.json:multiformats_config/' \
-    --add-data './src/algokit/resources:algokit/resources/' \
-    --osx-bundle-identifier \"$APPLE_BUNDLE_ID\" \
-    $(if [ -n \"$APPLE_CERT_ID\" ]; then echo \"--codesign-identity '$APPLE_CERT_ID'\"; fi) \
-    --osx-entitlements-file './entitlements.xml'"""
+package_mac = { cmd = "scripts/package_mac.sh" }
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,18 @@ docs_title = {shell = "(echo \"# AlgoKit CLI Reference Documentation\\n\\n\"; ca
 docs = ["docs_generate", "docs_toc", "docs_title"]
 package_unix = "pyinstaller --clean --onedir --hidden-import jinja2_ansible_filters --hidden-import multiformats_config --copy-metadata algokit --name algokit --noconfirm src/algokit/__main__.py --add-data './misc/multiformats_config:multiformats_config/' --add-data './src/algokit/resources:algokit/resources/'"
 package_windows = { cmd = "scripts/package_windows.bat" }
-package_mac = "pyinstaller --clean --onedir --hidden-import jinja2_ansible_filters --hidden-import multiformats_config --copy-metadata algokit --name algokit --noconfirm src/algokit/__main__.py --add-data './misc/multiformats_config/multibase-table.json:multiformats_config/' --add-data './misc/multiformats_config/multicodec-table.json:multiformats_config/' --add-data './src/algokit/resources:algokit/resources/' --osx-bundle-identifier \"$APPLE_BUNDLE_ID\" --codesign-identity \"$APPLE_CERT_ID\" --osx-entitlements-file './entitlements.xml'"
+package_mac.shell = """pyinstaller --clean --onedir \
+    --hidden-import jinja2_ansible_filters \
+    --hidden-import multiformats_config \
+    --copy-metadata algokit \
+    --name algokit \
+    --noconfirm src/algokit/__main__.py \
+    --add-data './misc/multiformats_config/multibase-table.json:multiformats_config/' \
+    --add-data './misc/multiformats_config/multicodec-table.json:multiformats_config/' \
+    --add-data './src/algokit/resources:algokit/resources/' \
+    --osx-bundle-identifier \"$APPLE_BUNDLE_ID\" \
+    $(if [ -n \"$APPLE_CERT_ID\" ]; then echo \"--codesign-identity '$APPLE_CERT_ID'\"; fi) \
+    --osx-entitlements-file './entitlements.xml'"""
 
 [tool.ruff]
 line-length = 120

--- a/scripts/package_mac.sh
+++ b/scripts/package_mac.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+CMD="pyinstaller --clean --onedir --hidden-import jinja2_ansible_filters --hidden-import multiformats_config --copy-metadata algokit --name algokit --noconfirm src/algokit/__main__.py --add-data './misc/multiformats_config/multibase-table.json:multiformats_config/' --add-data './misc/multiformats_config/multicodec-table.json:multiformats_config/' --add-data './src/algokit/resources:algokit/resources/'"
+
+if [ ! -z "$APPLE_BUNDLE_ID" ]; then
+    CMD="$CMD --osx-bundle-identifier \"$APPLE_BUNDLE_ID\""
+fi
+
+if [ ! -z "$APPLE_CERT_ID" ]; then
+    CMD="$CMD --codesign-identity \"$APPLE_CERT_ID\""
+fi
+
+if [ -f "./entitlements.xml" ]; then
+    CMD="$CMD --osx-entitlements-file './entitlements.xml'"
+fi
+
+eval $CMD 


### PR DESCRIPTION
The main gist is to further refine access to secrets to ensure none are accessed on PR triggers. Codesigning shall only run on production releases on main branch OR cron triggered checks performed weekly (8am UTC mondays) on main branch. 

## Proposed Changes
  - Add a new "with_codesign" parameter to macOS and Windows build actions to control whether binaries should be signed.
  - Update the build-binaries workflow to determine code-signing eligibility (via a new "signing" step) based on branch, PR status, and release conditions.
  - Update the macOS composite action to set "APPLE_CERT_ID" and "APPLE_BUNDLE_ID" conditionally, falling back to a beta bundle ID when "production_release" is false.
  - Replace references to "production_release" in the Windows build action with "with_codesign" for consistency.
  - Modify pyproject.toml to allow conditional code signing by passing in environment variables, ensuring more flexible signing logic for macOS binaries.