### PR TITLE
Beaker Full Deprecation

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -639,7 +639,7 @@ Name of an official template to use. To choose interactively, run this command w
 
 * **Options**
 
-    tealscript | python | react | fullstack | base | playground
+    tealscript | python | react | fullstack | base
 
 
 

--- a/src/algokit/cli/init.py
+++ b/src/algokit/cli/init.py
@@ -84,7 +84,6 @@ class TemplateKey(str, Enum):
     TEALSCRIPT = "tealscript"
     FULLSTACK = "fullstack"
     REACT = "react"
-    BEAKER = "beaker"
     PLAYGROUND = "playground"
 
 

--- a/src/algokit/cli/init.py
+++ b/src/algokit/cli/init.py
@@ -649,7 +649,7 @@ def _get_template_interactive() -> TemplateSource:
         raise click.ClickException("No template selected. Please try again.")
 
     # Map the template string directly to the TemplateSource
-    # This is needed to be able to reuse fullstack to work with beaker, python, and tealscript templates
+    # This is needed to be able to reuse fullstack to work with python and tealscript templates
     blessed_templates = _get_blessed_templates()
     if template in blessed_templates:
         selected_template_source = blessed_templates[template]

--- a/src/algokit/cli/init.py
+++ b/src/algokit/cli/init.py
@@ -84,7 +84,6 @@ class TemplateKey(str, Enum):
     TEALSCRIPT = "tealscript"
     FULLSTACK = "fullstack"
     REACT = "react"
-    PLAYGROUND = "playground"
 
 
 @dataclass(kw_only=True)
@@ -140,10 +139,6 @@ def _get_blessed_templates() -> dict[TemplateKey, BlessedTemplateSource]:
         TemplateKey.BASE: BlessedTemplateSource(
             url="gh:algorandfoundation/algokit-base-template",
             description="Official base template for enforcing workspace structure for standalone AlgoKit projects.",
-        ),
-        TemplateKey.PLAYGROUND: BlessedTemplateSource(
-            url="gh:algorandfoundation/algokit-beaker-playground-template",
-            description="Official template showcasing a number of small example applications and demos.",
         ),
     }
 

--- a/tests/init/test_init.py
+++ b/tests/init/test_init.py
@@ -89,7 +89,6 @@ class ExtendedTemplateKey(str, Enum):
     TEALSCRIPT = "tealscript"
     FULLSTACK = "fullstack"
     REACT = "react"
-    PLAYGROUND = "playground"
     PYTHON_WITH_VERSION = "python_with_version"
     SIMPLE = "simple"
 


### PR DESCRIPTION
This PR addresses:
- Orphan `BEAKER` enum item in `TemplateKey` after the Beaker default template deprecation.
- The AlgoKit CLI side of the Beaker playground template deprecation.

Companion PR: algorandfoundation/algokit-beaker-playground-template#14