### PR TITLE
Fix configured localnet

### DIFF
--- a/src/algokit/core/sandbox.py
+++ b/src/algokit/core/sandbox.py
@@ -119,13 +119,15 @@ class ComposeSandbox:
     def _create_instance_from_data(cls, data: list[dict[str, Any]]) -> ComposeSandbox | None:
         for item in data:
             config_file = item.get("ConfigFiles", "").split(",")[0]
-            full_name = Path(config_file).parent.name
+            config_file_path = Path(config_file)
+            full_name = config_file_path.parent.name
             name = (
                 full_name.replace(f"{SANDBOX_BASE_NAME}_", "")
                 if full_name.startswith(f"{SANDBOX_BASE_NAME}_")
                 else full_name
             )
-            return cls(name)
+            config_path = config_file_path.parent.parent
+            return cls(name, config_path)
         return None
 
     def set_algod_dev_mode(self, *, dev_mode: bool) -> None:

--- a/tests/goal/test_goal.py
+++ b/tests/goal/test_goal.py
@@ -519,13 +519,13 @@ def test_goal_compose_outdated(
     verify(_normalize_output(result.output))
 
 
-@pytest.mark.usefixtures("_setup_latest_dummy_compose", "mocked_goal_mount_path", "_mock_proc_with_algod_running_state")
-def test_goal_simple_args_on_named_localnet(proc_mock: ProcMock, app_dir_mock: AppDirs) -> None:
-    proc_mock.set_output(
-        "docker compose ls --format json --filter name=algokit_sandbox*",
-        [json.dumps([{"Name": "algokit_test", "Status": "running", "ConfigFiles": "to/test/docker-compose.yml"}])],
-    )
-
+@pytest.mark.usefixtures(
+    "_setup_latest_dummy_compose",
+    "mocked_goal_mount_path",
+    "_mock_proc_with_algod_running_state",
+    "_mock_proc_with_running_localnet",
+)
+def test_goal_simple_args_on_named_localnet(app_dir_mock: AppDirs) -> None:
     result = invoke("goal account list")
 
     assert result.exit_code == 0

--- a/tests/goal/test_goal.py
+++ b/tests/goal/test_goal.py
@@ -114,7 +114,9 @@ def test_goal_no_args(app_dir_mock: AppDirs) -> None:
     result = invoke("goal")
 
     assert result.exit_code == 0
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -131,7 +133,9 @@ def test_goal_console(mocker: MockerFixture, app_dir_mock: AppDirs) -> None:
     result = invoke("goal --console")
 
     assert result.exit_code == 0
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures("_setup_latest_dummy_compose", "_mock_proc_with_running_localnet", "_health_success")
@@ -145,7 +149,9 @@ def test_goal_console_algod_not_created(app_dir_mock: AppDirs, proc_mock: ProcMo
     result = invoke("goal --console")
 
     assert result.exit_code == 0
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -162,7 +168,9 @@ def test_goal_console_failed(app_dir_mock: AppDirs, mocker: MockerFixture) -> No
     result = invoke("goal --console")
 
     assert result.exit_code == 1
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -176,7 +184,9 @@ def test_goal_simple_args(app_dir_mock: AppDirs) -> None:
     result = invoke("goal account list")
 
     assert result.exit_code == 0
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -190,7 +200,9 @@ def test_goal_complex_args(app_dir_mock: AppDirs) -> None:
     result = invoke("goal account export -a RKTAZY2ZLKUJBHDVVA3KKHEDK7PRVGIGOZAUUIZBNK2OEP6KQGEXKKUYUY")
 
     assert result.exit_code == 0
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 def test_goal_start_without_docker(proc_mock: ProcMock) -> None:
@@ -245,7 +257,9 @@ def test_goal_simple_args_with_input_file(
     # Check for the result status
     assert result.exit_code == 0
 
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -284,7 +298,9 @@ def test_goal_simple_args_with_output_file(proc_mock: ProcMock, cwd: Path, app_d
     # Check if the output file is actually created and copied in cwd in postprocess step
     assert (cwd / "balance_record.json").exists()
 
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -329,7 +345,9 @@ def test_goal_simple_args_with_input_output_files(
 
     # Check if the output file is created and copied in cwd in postprocess step
     assert (cwd / "approval.compiled").exists()
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -381,7 +399,9 @@ def test_goal_simple_args_with_multiple_input_output_files(
 
     # Check if the output file is actually created and copied in cwd in postprocess step
     assert (cwd / "approval.compiled").exists()
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -399,7 +419,9 @@ def test_goal_simple_args_without_file_error(
     result = invoke("goal clerk compile approval.teal -o approval.compiled", cwd=cwd)
 
     assert result.exit_code == 1
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -529,7 +551,9 @@ def test_goal_simple_args_on_named_localnet(app_dir_mock: AppDirs) -> None:
     result = invoke("goal account list")
 
     assert result.exit_code == 0
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -574,4 +598,6 @@ def test_goal_simple_args_with_input_output_files_with_dot_convention_name(
 
     # Check if the output file is created and copied in cwd in postprocess step
     assert (cwd / "approval.compiled").exists()
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )

--- a/tests/goal/test_goal.test_goal_simple_args_on_named_localnet.approved.txt
+++ b/tests/goal/test_goal.test_goal_simple_args_on_named_localnet.approved.txt
@@ -2,11 +2,9 @@ DEBUG: Running '{container_engine} version' in '{current_working_directory}'
 DEBUG: {container_engine}: STDOUT
 DEBUG: {container_engine}: STDERR
 DEBUG: Running '{container_engine} compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: {container_engine}: [{"Name": "algokit_test", "Status": "running", "ConfigFiles": "to/test/{container_engine}-compose.yml"}]
-DEBUG: The sandbox_test directory does not exist yet; creating it
-A named LocalNet is running, goal command will be executed against the named LocalNet
-DEBUG: Running '{container_engine} compose ps algod --format json' in '{app_config}/sandbox_test'
+DEBUG: {container_engine}: []
+DEBUG: Running '{container_engine} compose ps algod --format json' in '{app_config}/sandbox'
 DEBUG: {container_engine}: [{"Name": "algokit_sandbox_algod", "State": "running"}]
-DEBUG: Running '{container_engine} exec --interactive --workdir /root algokit_sandbox_test_algod goal account list' in '{current_working_directory}'
+DEBUG: Running '{container_engine} exec --interactive --workdir /root algokit_sandbox_algod goal account list' in '{current_working_directory}'
  STDOUT
  STDERR

--- a/tests/localnet/conftest.py
+++ b/tests/localnet/conftest.py
@@ -51,8 +51,8 @@ def _localnet_up_to_date(proc_mock: ProcMock, httpx_mock: HTTPXMock) -> None:
 
 @pytest.fixture()
 def _mock_proc_with_running_localnet(proc_mock: ProcMock, app_dir_mock: AppDirs) -> None:
-    app_dir_path = str(app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml")
+    compose_file_path = str(app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml")
     proc_mock.set_output(
         "docker compose ls --format json --filter name=algokit_sandbox*",
-        [json.dumps([{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": app_dir_path}])],
+        [json.dumps([{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": compose_file_path}])],
     )

--- a/tests/localnet/conftest.py
+++ b/tests/localnet/conftest.py
@@ -5,6 +5,7 @@ from algokit.core.sandbox import ALGOD_HEALTH_URL, ALGORAND_IMAGE, INDEXER_IMAGE
 from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
 
+from tests.utils.app_dir_mock import AppDirs
 from tests.utils.proc_mock import ProcMock
 
 
@@ -49,12 +50,9 @@ def _localnet_up_to_date(proc_mock: ProcMock, httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.fixture()
-def _mock_proc_with_running_localnet(proc_mock: ProcMock) -> None:
+def _mock_proc_with_running_localnet(proc_mock: ProcMock, app_dir_mock: AppDirs) -> None:
+    app_dir_path = str(app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml")
     proc_mock.set_output(
         "docker compose ls --format json --filter name=algokit_sandbox*",
-        [
-            json.dumps(
-                [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
-            )
-        ],
+        [json.dumps([{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": app_dir_path}])],
     )

--- a/tests/localnet/test_localnet_console.py
+++ b/tests/localnet/test_localnet_console.py
@@ -39,4 +39,6 @@ def test_goal_console(
     result = invoke("localnet console")
 
     assert result.exit_code == 0
-    verify(_normalize_output(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}")))
+    verify(
+        _normalize_output(result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}"))
+    )

--- a/tests/localnet/test_localnet_console.py
+++ b/tests/localnet/test_localnet_console.py
@@ -12,6 +12,7 @@ from tests.utils.click_invoker import invoke
 from tests.utils.proc_mock import ProcMock
 
 
+@pytest.mark.usefixtures("_mock_proc_with_running_localnet")
 def test_goal_console(
     mocker: MockerFixture, tmp_path_factory: pytest.TempPathFactory, app_dir_mock: AppDirs, proc_mock: ProcMock
 ) -> None:
@@ -29,20 +30,6 @@ def test_goal_console(
 
     mocker.patch("algokit.core.proc.subprocess_run").return_value = CompletedProcess(
         ["docker", "exec"], 0, "STDOUT+STDERR"
-    )
-    proc_mock.set_output(
-        "docker compose ls --format json --filter name=algokit_sandbox*",
-        [
-            json.dumps(
-                [
-                    {
-                        "Name": "algokit_sandbox",
-                        "Status": "running",
-                        "ConfigFiles": "test/sandbox_test/docker-compose.yml",
-                    }
-                ]
-            )
-        ],
     )
     proc_mock.set_output(
         cmd=["docker", "compose", "ps", "algod", "--format", "json"],

--- a/tests/localnet/test_localnet_console.test_goal_console.approved.txt
+++ b/tests/localnet/test_localnet_console.test_goal_console.approved.txt
@@ -7,10 +7,8 @@ DEBUG: Running '{container_engine} version' in '{current_working_directory}'
 DEBUG: {container_engine}: STDOUT
 DEBUG: {container_engine}: STDERR
 DEBUG: Running '{container_engine} compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: {container_engine}: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox_test/{container_engine}-compose.yml"}]
-DEBUG: The sandbox_test directory does not exist yet; creating it
-A named LocalNet is running, goal command will be executed against the named LocalNet
-DEBUG: Running '{container_engine} compose ps algod --format json' in '{app_config}/sandbox_test'
+DEBUG: {container_engine}: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/{container_engine}-compose.yml"}]
+DEBUG: Running '{container_engine} compose ps algod --format json' in '{app_config}/sandbox'
 DEBUG: {container_engine}: [{"Name": "algokit_sandbox_algod", "State": "running"}]
 Opening Bash console on the algod node; execute `exit` to return to original console
-DEBUG: Running '{container_engine} exec -it -w /root algokit_sandbox_test_algod bash' in '{current_working_directory}'
+DEBUG: Running '{container_engine} exec -it -w /root algokit_sandbox_algod bash' in '{current_working_directory}'

--- a/tests/localnet/test_localnet_reset.py
+++ b/tests/localnet/test_localnet_reset.py
@@ -15,7 +15,9 @@ def test_localnet_reset_without_existing_sandbox(app_dir_mock: AppDirs) -> None:
     assert result.exit_code == 0
     verify(
         get_combined_verify_output(
-            result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+            result.output.replace("\\\\", "\\")
+            .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+            .replace("\\", "/"),
             "{app_config}/sandbox/docker-compose.yml",
             (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").read_text(),
         )
@@ -34,7 +36,9 @@ def test_localnet_reset_with_existing_sandbox_with_out_of_date_config(app_dir_mo
     verify(
         "\n".join(
             [
-                result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+                result.output.replace("\\\\", "\\")
+                .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+                .replace("\\", "/"),
                 "{app_config}/sandbox/docker-compose.yml",
                 (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").read_text(),
                 "{app_config}/sandbox/algod_config.json",
@@ -55,7 +59,9 @@ def test_localnet_reset_with_existing_sandbox_with_up_to_date_config(app_dir_moc
     result = invoke("localnet reset")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("proc_mock", "_health_success", "_mock_proc_with_running_localnet")
@@ -73,7 +79,9 @@ def test_localnet_reset_with_named_sandbox_config(app_dir_mock: AppDirs) -> None
     result = invoke("localnet reset")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures(
@@ -89,7 +97,9 @@ def test_localnet_reset_with_existing_sandbox_with_up_to_date_config_with_pull(a
     result = invoke("localnet reset --update")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("app_dir_mock", "_mock_proc_with_running_localnet")

--- a/tests/localnet/test_localnet_reset.py
+++ b/tests/localnet/test_localnet_reset.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from algokit.core.sandbox import get_algod_network_template, get_config_json, get_docker_compose_yml, get_proxy_config
 
@@ -64,8 +66,13 @@ def test_localnet_reset_with_existing_sandbox_with_up_to_date_config(app_dir_moc
     )
 
 
-@pytest.mark.usefixtures("proc_mock", "_health_success", "_mock_proc_with_running_localnet")
-def test_localnet_reset_with_named_sandbox_config(app_dir_mock: AppDirs) -> None:
+@pytest.mark.usefixtures("proc_mock", "_health_success")
+def test_localnet_reset_with_named_sandbox_config(proc_mock: ProcMock, app_dir_mock: AppDirs) -> None:
+    compose_file_path = str(app_dir_mock.app_config_dir / "sandbox_test" / "docker-compose.yml")
+    proc_mock.set_output(
+        "docker compose ls --format json --filter name=algokit_sandbox*",
+        [json.dumps([{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": compose_file_path}])],
+    )
     (app_dir_mock.app_config_dir / "sandbox_test").mkdir()
     (app_dir_mock.app_config_dir / "sandbox_test" / "docker-compose.yml").write_text(
         get_docker_compose_yml(name="algokit_sandbox_test")

--- a/tests/localnet/test_localnet_reset.py
+++ b/tests/localnet/test_localnet_reset.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from algokit.core.sandbox import get_algod_network_template, get_config_json, get_docker_compose_yml, get_proxy_config
 
@@ -60,22 +58,8 @@ def test_localnet_reset_with_existing_sandbox_with_up_to_date_config(app_dir_moc
     verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
 
 
-@pytest.mark.usefixtures("proc_mock", "_health_success")
-def test_localnet_reset_with_named_sandbox_config(app_dir_mock: AppDirs, proc_mock: ProcMock) -> None:
-    proc_mock.set_output(
-        "docker compose ls --format json --filter name=algokit_sandbox*",
-        [
-            json.dumps(
-                [
-                    {
-                        "Name": "algokit_sandbox_test",
-                        "Status": "running",
-                        "ConfigFiles": "sandbox_test/docker-compose.yml",
-                    }
-                ]
-            )
-        ],
-    )
+@pytest.mark.usefixtures("proc_mock", "_health_success", "_mock_proc_with_running_localnet")
+def test_localnet_reset_with_named_sandbox_config(app_dir_mock: AppDirs) -> None:
     (app_dir_mock.app_config_dir / "sandbox_test").mkdir()
     (app_dir_mock.app_config_dir / "sandbox_test" / "docker-compose.yml").write_text(
         get_docker_compose_yml(name="algokit_sandbox_test")

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 Cleaning up the running AlgoKit LocalNet...
 DEBUG: Running 'docker compose down' in '{app_config}/sandbox'
 DEBUG: docker: STDOUT

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 Cleaning up the running AlgoKit LocalNet...
 DEBUG: Running 'docker compose down' in '{app_config}/sandbox'
 DEBUG: docker: STDOUT

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config_with_pull.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config_with_pull.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 Cleaning up the running AlgoKit LocalNet...
 DEBUG: Running 'docker compose down' in '{app_config}/sandbox'
 DEBUG: docker: STDOUT

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
@@ -6,11 +6,11 @@ DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
 DEBUG: docker: [{"Name": "algokit_sandbox_test", "Status": "running", "ConfigFiles": "sandbox_test/docker-compose.yml"}]
 Cleaning up the running AlgoKit LocalNet...
-DEBUG: Running 'docker compose down' in '{app_config}/sandbox_test'
+DEBUG: Running 'docker compose down' in 'sandbox_test'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 Starting AlgoKit LocalNet now...
-DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in '{app_config}/sandbox_test'
+DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in 'sandbox_test'
 docker: STDOUT
 docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
@@ -4,13 +4,11 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox_test", "Status": "running", "ConfigFiles": "sandbox_test/docker-compose.yml"}]
-Cleaning up the running AlgoKit LocalNet...
-DEBUG: Running 'docker compose down' in 'sandbox_test'
-DEBUG: docker: STDOUT
-DEBUG: docker: STDERR
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
+DEBUG: The sandbox directory does not exist yet; creating it
+DEBUG: Existing LocalNet not found; creating from scratch...
 Starting AlgoKit LocalNet now...
-DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in 'sandbox_test'
+DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in '{app_config}/sandbox'
 docker: STDOUT
 docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
@@ -4,11 +4,13 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
-DEBUG: The sandbox directory does not exist yet; creating it
-DEBUG: Existing LocalNet not found; creating from scratch...
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox_test/docker-compose.yml"}]
+Cleaning up the running AlgoKit LocalNet...
+DEBUG: Running 'docker compose down' in '{app_config}/sandbox_test'
+DEBUG: docker: STDOUT
+DEBUG: docker: STDERR
 Starting AlgoKit LocalNet now...
-DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in '{app_config}/sandbox'
+DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in '{app_config}/sandbox_test'
 docker: STDOUT
 docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Existing LocalNet not found; creating from scratch...
 Starting AlgoKit LocalNet now...

--- a/tests/localnet/test_localnet_start.py
+++ b/tests/localnet/test_localnet_start.py
@@ -63,7 +63,9 @@ def test_localnet_start(app_dir_mock: AppDirs) -> None:
     assert result.exit_code == 0
     verify(
         get_combined_verify_output(
-            result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+            result.output.replace("\\\\", "\\")
+            .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+            .replace("\\", "/"),
             "{app_config}/sandbox/docker-compose.yml",
             (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").read_text(),
         )
@@ -91,7 +93,9 @@ def test_localnet_start_with_name(app_dir_mock: AppDirs, proc_mock: ProcMock) ->
     assert result.exit_code == 0
     verify(
         get_combined_verify_output(
-            result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+            result.output.replace("\\\\", "\\")
+            .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+            .replace("\\", "/"),
             "{app_config}/sandbox_test/docker-compose.yml",
             (app_dir_mock.app_config_dir / "sandbox_test" / "docker-compose.yml").read_text(),
         )
@@ -106,7 +110,9 @@ def test_localnet_start_health_failure(app_dir_mock: AppDirs, httpx_mock: HTTPXM
     assert result.exit_code == 0
     verify(
         get_combined_verify_output(
-            result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+            result.output.replace("\\\\", "\\")
+            .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+            .replace("\\", "/"),
             "{app_config}/sandbox/docker-compose.yml",
             (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").read_text(),
         )
@@ -121,7 +127,9 @@ def test_localnet_start_health_bad_status(app_dir_mock: AppDirs, httpx_mock: HTT
     assert result.exit_code == 0
     verify(
         get_combined_verify_output(
-            result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+            result.output.replace("\\\\", "\\")
+            .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+            .replace("\\", "/"),
             "{app_config}/sandbox/docker-compose.yml",
             (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").read_text(),
         )
@@ -135,7 +143,9 @@ def test_localnet_start_failure(app_dir_mock: AppDirs, proc_mock: ProcMock) -> N
     result = invoke("localnet start")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("proc_mock", "_health_success", "_localnet_up_to_date", "_mock_proc_with_running_localnet")
@@ -149,7 +159,9 @@ def test_localnet_start_up_to_date_definition(app_dir_mock: AppDirs) -> None:
     result = invoke("localnet start")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("proc_mock", "_health_success", "_localnet_up_to_date", "_mock_proc_with_running_localnet")
@@ -167,7 +179,9 @@ def test_localnet_start_out_of_date_definition(app_dir_mock: AppDirs, mocker: Mo
     verify(
         "\n".join(
             [
-                result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+                result.output.replace("\\\\", "\\")
+                .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+                .replace("\\", "/"),
                 "{app_config}/sandbox/docker-compose.yml",
                 (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").read_text(),
                 "{app_config}/sandbox/algod_config.json",
@@ -192,7 +206,9 @@ def test_localnet_start_out_of_date_definition_and_missing_config(app_dir_mock: 
     verify(
         "\n".join(
             [
-                result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"),
+                result.output.replace("\\\\", "\\")
+                .replace(str(app_dir_mock.app_config_dir), "{app_config}")
+                .replace("\\", "/"),
                 "{app_config}/sandbox/docker-compose.yml",
                 (app_dir_mock.app_config_dir / "sandbox" / "docker-compose.yml").read_text(),
             ]
@@ -247,7 +263,9 @@ def test_localnet_start_with_unparseable_docker_compose_version(app_dir_mock: Ap
     result = invoke("localnet start")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_health_success", "_localnet_up_to_date", "_mock_proc_with_running_localnet")
@@ -257,7 +275,9 @@ def test_localnet_start_with_gitpod_docker_compose_version(app_dir_mock: AppDirs
     result = invoke("localnet start")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("proc_mock", "_health_success", "_localnet_out_of_date", "_mock_proc_with_running_localnet")
@@ -265,7 +285,9 @@ def test_localnet_start_out_date(app_dir_mock: AppDirs) -> None:
     result = invoke("localnet start")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures(
@@ -275,7 +297,9 @@ def test_localnet_img_check_cmd_error(app_dir_mock: AppDirs) -> None:
     result = invoke("localnet start")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("proc_mock", "_health_success", "_localnet_up_to_date", "_mock_proc_with_running_localnet")

--- a/tests/localnet/test_localnet_start.py
+++ b/tests/localnet/test_localnet_start.py
@@ -80,7 +80,7 @@ def test_localnet_start_with_name(app_dir_mock: AppDirs, proc_mock: ProcMock) ->
                     {
                         "Name": "algokit_sandbox_test",
                         "Status": "running",
-                        "ConfigFiles": "sandbox_test/docker-compose.yml",
+                        "ConfigFiles": str(app_dir_mock.app_config_dir / "sandbox_test" / "docker-compose.yml"),
                     }
                 ]
             )

--- a/tests/localnet/test_localnet_start.test_localnet_img_check_cmd_error.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_img_check_cmd_error.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: Failed to get local image versions: No such file or directory: docker

--- a/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/localnet/test_localnet_start.test_localnet_start_failure.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_failure.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_bad_status.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/localnet/test_localnet_start.test_localnet_start_out_date.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_out_date.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 DEBUG: HTTP Request: GET https://registry.hub.docker.com/v2/repositories/algorand/indexer/tags/latest "HTTP/1.1 200 OK"

--- a/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition_and_missing_config.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition_and_missing_config.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 DEBUG: HTTP Request: GET https://registry.hub.docker.com/v2/repositories/algorand/indexer/tags/latest "HTTP/1.1 200 OK"

--- a/tests/localnet/test_localnet_start.test_localnet_start_up_to_date_definition.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_up_to_date_definition.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 DEBUG: HTTP Request: GET https://registry.hub.docker.com/v2/repositories/algorand/indexer/tags/latest "HTTP/1.1 200 OK"

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_gitpod_docker_compose_version.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_gitpod_docker_compose_version.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox_test", "Status": "running", "ConfigFiles": "sandbox_test/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox_test", "Status": "running", "ConfigFiles": "{app_config}/sandbox_test/docker-compose.yml"}]
 DEBUG: The sandbox_test directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_unparseable_docker_compose_version.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_unparseable_docker_compose_version.approved.txt
@@ -7,7 +7,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 DEBUG: Running 'docker image inspect algorand/indexer:latest --format {{range .RepoDigests}}{{println .}}{{end}}' in '{current_working_directory}'
 DEBUG: docker: tag@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/tests/localnet/test_localnet_status.py
+++ b/tests/localnet/test_localnet_status.py
@@ -37,7 +37,9 @@ def test_localnet_status_successful(app_dir_mock: AppDirs, proc_mock: ProcMock, 
     result = invoke("localnet status")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_mock_proc_with_running_localnet")
@@ -65,7 +67,9 @@ def test_localnet_status_http_error(app_dir_mock: AppDirs, proc_mock: ProcMock, 
     result = invoke("localnet status")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_mock_proc_with_running_localnet")
@@ -92,7 +96,9 @@ def test_localnet_status_unexpected_port(app_dir_mock: AppDirs, proc_mock: ProcM
     result = invoke("localnet status")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_mock_proc_with_running_localnet")
@@ -111,7 +117,9 @@ def test_localnet_status_service_not_started(app_dir_mock: AppDirs, proc_mock: P
     result = invoke("localnet status")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_mock_proc_with_running_localnet")
@@ -138,7 +146,9 @@ def test_localnet_status_docker_error(app_dir_mock: AppDirs, proc_mock: ProcMock
     result = invoke("localnet status")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_mock_proc_with_running_localnet")
@@ -185,7 +195,9 @@ def test_localnet_status_missing_service(app_dir_mock: AppDirs, proc_mock: ProcM
 
     assert result.exit_code == 1
     assert not httpx_mock.get_request()
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_mock_proc_with_running_localnet")
@@ -197,7 +209,9 @@ def test_localnet_status_failure(app_dir_mock: AppDirs, proc_mock: ProcMock) -> 
     result = invoke("localnet status")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("proc_mock", "_mock_proc_with_running_localnet")
@@ -205,7 +219,9 @@ def test_localnet_status_no_existing_definition(app_dir_mock: AppDirs) -> None:
     result = invoke("localnet status")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("app_dir_mock")

--- a/tests/localnet/test_localnet_status.test_localnet_status_docker_error.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_docker_error.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 # container engine
 Name: docker (change with `algokit config container-engine`)
 DEBUG: Running 'docker compose ps --format json' in '{app_config}/sandbox'

--- a/tests/localnet/test_localnet_status.test_localnet_status_failure.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_failure.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 # container engine
 Name: docker (change with `algokit config container-engine`)
 DEBUG: Running 'docker compose ps --format json' in '{app_config}/sandbox'

--- a/tests/localnet/test_localnet_status.test_localnet_status_http_error.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_http_error.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 # container engine
 Name: docker (change with `algokit config container-engine`)
 DEBUG: Running 'docker compose ps --format json' in '{app_config}/sandbox'

--- a/tests/localnet/test_localnet_status.test_localnet_status_missing_service.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_missing_service.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 # container engine
 Name: docker (change with `algokit config container-engine`)
 DEBUG: Running 'docker compose ps --format json' in '{app_config}/sandbox'

--- a/tests/localnet/test_localnet_status.test_localnet_status_no_existing_definition.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_no_existing_definition.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it
 # container engine
 Name: docker (change with `algokit config container-engine`)

--- a/tests/localnet/test_localnet_status.test_localnet_status_service_not_started.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_service_not_started.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 # container engine
 Name: docker (change with `algokit config container-engine`)
 DEBUG: Running 'docker compose ps --format json' in '{app_config}/sandbox'

--- a/tests/localnet/test_localnet_status.test_localnet_status_successful.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_successful.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 # container engine
 Name: docker (change with `algokit config container-engine`)
 DEBUG: Running 'docker compose ps --format json' in '{app_config}/sandbox'

--- a/tests/localnet/test_localnet_status.test_localnet_status_unexpected_port.approved.txt
+++ b/tests/localnet/test_localnet_status.test_localnet_status_unexpected_port.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 # container engine
 Name: docker (change with `algokit config container-engine`)
 DEBUG: Running 'docker compose ps --format json' in '{app_config}/sandbox'

--- a/tests/localnet/test_localnet_stop.py
+++ b/tests/localnet/test_localnet_stop.py
@@ -32,7 +32,7 @@ def test_localnet_stop_with_name(app_dir_mock: AppDirs, proc_mock: ProcMock) -> 
                     {
                         "Name": "algokit_sandbox_test",
                         "Status": "running",
-                        "ConfigFiles": "sandbox_test/docker-compose.yml",
+                        "ConfigFiles": str(app_dir_mock.app_config_dir / "sandbox_test" / "docker-compose.yml"),
                     }
                 ]
             )

--- a/tests/localnet/test_localnet_stop.py
+++ b/tests/localnet/test_localnet_stop.py
@@ -17,7 +17,9 @@ def test_localnet_stop(app_dir_mock: AppDirs) -> None:
     result = invoke("localnet stop")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 def test_localnet_stop_with_name(app_dir_mock: AppDirs, proc_mock: ProcMock) -> None:
@@ -41,7 +43,9 @@ def test_localnet_stop_with_name(app_dir_mock: AppDirs, proc_mock: ProcMock) -> 
     result = invoke("localnet stop")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("_mock_proc_with_running_localnet")
@@ -54,7 +58,9 @@ def test_localnet_stop_failure(app_dir_mock: AppDirs, proc_mock: ProcMock) -> No
     result = invoke("localnet stop")
 
     assert result.exit_code == 1
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("proc_mock", "_mock_proc_with_running_localnet")
@@ -62,7 +68,9 @@ def test_localnet_stop_no_existing_definition(app_dir_mock: AppDirs) -> None:
     result = invoke("localnet stop")
 
     assert result.exit_code == 0
-    verify(result.output.replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/"))
+    verify(
+        result.output.replace("\\\\", "\\").replace(str(app_dir_mock.app_config_dir), "{app_config}").replace("\\", "/")
+    )
 
 
 @pytest.mark.usefixtures("app_dir_mock")

--- a/tests/localnet/test_localnet_stop.test_localnet_stop.approved.txt
+++ b/tests/localnet/test_localnet_stop.test_localnet_stop.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 Stopping AlgoKit LocalNet now...
 DEBUG: Running 'docker compose stop' in '{app_config}/sandbox'
 docker: STDOUT

--- a/tests/localnet/test_localnet_stop.test_localnet_stop_failure.approved.txt
+++ b/tests/localnet/test_localnet_stop.test_localnet_stop_failure.approved.txt
@@ -4,7 +4,7 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 Stopping AlgoKit LocalNet now...
 DEBUG: Running 'docker compose stop' in '{app_config}/sandbox'
 docker: STDOUT

--- a/tests/localnet/test_localnet_stop.test_localnet_stop_no_existing_definition.approved.txt
+++ b/tests/localnet/test_localnet_stop.test_localnet_stop_no_existing_definition.approved.txt
@@ -4,5 +4,5 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "test/sandbox/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox", "Status": "running", "ConfigFiles": "{app_config}/sandbox/docker-compose.yml"}]
 DEBUG: The sandbox directory does not exist yet; creating it

--- a/tests/localnet/test_localnet_stop.test_localnet_stop_with_name.approved.txt
+++ b/tests/localnet/test_localnet_stop.test_localnet_stop_with_name.approved.txt
@@ -6,7 +6,7 @@ DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
 DEBUG: docker: [{"Name": "algokit_sandbox_test", "Status": "running", "ConfigFiles": "sandbox_test/docker-compose.yml"}]
 Stopping AlgoKit LocalNet now...
-DEBUG: Running 'docker compose stop' in '{app_config}/sandbox_test'
+DEBUG: Running 'docker compose stop' in 'sandbox_test'
 docker: STDOUT
 docker: STDERR
 LocalNet Stopped; execute `algokit localnet start` to start it again.

--- a/tests/localnet/test_localnet_stop.test_localnet_stop_with_name.approved.txt
+++ b/tests/localnet/test_localnet_stop.test_localnet_stop_with_name.approved.txt
@@ -4,9 +4,9 @@ DEBUG: Running 'docker version' in '{current_working_directory}'
 DEBUG: docker: STDOUT
 DEBUG: docker: STDERR
 DEBUG: Running 'docker compose ls --format json --filter name=algokit_sandbox*' in '{current_working_directory}'
-DEBUG: docker: [{"Name": "algokit_sandbox_test", "Status": "running", "ConfigFiles": "sandbox_test/docker-compose.yml"}]
+DEBUG: docker: [{"Name": "algokit_sandbox_test", "Status": "running", "ConfigFiles": "{app_config}/sandbox_test/docker-compose.yml"}]
 Stopping AlgoKit LocalNet now...
-DEBUG: Running 'docker compose stop' in 'sandbox_test'
+DEBUG: Running 'docker compose stop' in '{app_config}/sandbox_test'
 docker: STDOUT
 docker: STDERR
 LocalNet Stopped; execute `algokit localnet start` to start it again.


### PR DESCRIPTION
Fixes AK-71

Improves LocalNet configuration management by using absolute paths instead of relative paths. This ensures more reliable and consistent behavior when managing LocalNet instances across different environments.

Key changes:

- Use Path objects for proper path resolution in ComposeSandbox
- Update test fixtures to use absolute paths
- Standardize path handling across the codebase
- Updated tests to use the `_mock_proc_with_running_localnet` instead of proc_mock inside each test. 
- Updated the config_dir of the test to all be `sandbox`. Before it was a mixture of `sandbox_test` and `sandbox`
