### PR TITLE
fix: resolve project run issue by forcing utf-8 encoding on windows

### DIFF
--- a/src/algokit/cli/dispenser.py
+++ b/src/algokit/cli/dispenser.py
@@ -61,7 +61,7 @@ def _handle_ci_token(output_mode: str, output_filename: str, token_data: dict) -
             "If needed, clear your terminal history after copying the token!"
         )
     else:
-        with Path.open(Path(output_filename), "w") as token_file:
+        with Path.open(Path(output_filename), mode="w", encoding="utf-8") as token_file:
             token_file.write(token_data["access_token"])
         logger.warning(
             f"Your CI access token has been saved to `{output_filename}`.\n"

--- a/src/algokit/cli/project/link.py
+++ b/src/algokit/cli/project/link.py
@@ -239,5 +239,5 @@ def link_command(
             version=version,
         )
 
-        logger.info(f"✅ {iteration}/{total}: Finished processing {contract_project.project_name}")
+        logger.info(f"{iteration}/{total}: Finished processing {contract_project.project_name}")
         iteration += 1

--- a/src/algokit/cli/tasks/analyze.py
+++ b/src/algokit/cli/tasks/analyze.py
@@ -223,7 +223,7 @@ def analyze(  # noqa: PLR0913, C901
                 if has_diff:
                     raise click.exceptions.Exit(1)
 
-            reports[str(report_output_path.absolute())] = json.load(report_output_path.open())
+            reports[str(report_output_path.absolute())] = json.load(report_output_path.open(encoding="utf-8"))
         except Exception as e:
             if diff_only and old_report:
                 report_output_path.write_text(json.dumps(old_report.model_dump(by_alias=True), indent=2))

--- a/src/algokit/cli/tasks/mint.py
+++ b/src/algokit/cli/tasks/mint.py
@@ -92,7 +92,7 @@ def _get_and_validate_asset_name(context: click.Context, param: click.Parameter,
     token_name = None
 
     if token_metadata_path is not None:
-        with Path(token_metadata_path).open("r") as metadata_file:
+        with Path(token_metadata_path).open(mode="r", encoding="utf-8") as metadata_file:
             data = json.load(metadata_file)
             token_name = data.get("name")
 
@@ -147,7 +147,7 @@ def _get_and_validate_decimals(context: click.Context, _: click.Parameter, value
     token_metadata_path = context.params.get("token_metadata_path")
     token_decimals = None
     if token_metadata_path is not None:
-        with Path(token_metadata_path).open("r") as metadata_file:
+        with Path(token_metadata_path).open(mode="r", encoding="utf-8") as metadata_file:
             data = json.load(metadata_file)
             token_decimals = data.get("decimals")
 

--- a/src/algokit/cli/tasks/vanity_address.py
+++ b/src/algokit/cli/tasks/vanity_address.py
@@ -133,6 +133,6 @@ def vanity_address(  # noqa: PLR0913
     elif output == "alias" and alias:
         _store_vanity_to_alias(alias=alias, vanity_account=vanity_account, force=force)
     elif output == "file" and output_file_path is not None:
-        with output_file_path.open("w") as f:
+        with output_file_path.open(mode="w", encoding="utf-8") as f:
             json.dump(vanity_account.__dict__, f, indent=4)
             click.echo(f"Output written to {output_file_path.absolute()}")

--- a/src/algokit/core/init.py
+++ b/src/algokit/core/init.py
@@ -117,7 +117,7 @@ def append_project_to_vscode_workspace(project_path: Path, workspace_path: Path)
 
 def _load_vscode_workspace(workspace_path: Path) -> dict[str, Any]:
     """Load the workspace file as a JSON object."""
-    with workspace_path.open("r") as f:
+    with workspace_path.open(mode="r", encoding="utf-8") as f:
         data = json.load(f)
         assert isinstance(data, dict)
         return cast(dict[str, Any], data)
@@ -125,5 +125,5 @@ def _load_vscode_workspace(workspace_path: Path) -> dict[str, Any]:
 
 def _save_vscode_workspace(workspace_path: Path, workspace: dict) -> None:
     """Save the modified workspace back to the file."""
-    with workspace_path.open("w") as f:
+    with workspace_path.open(mode="w", encoding="utf-8") as f:
         json.dump(workspace, f, indent=2)

--- a/src/algokit/core/proc.py
+++ b/src/algokit/core/proc.py
@@ -48,6 +48,7 @@ def run(  # noqa: PLR0913
         cwd=cwd,
         env=env,
         bufsize=1,  # line buffering, works because text=True
+        encoding="utf-8",
     ) as proc:
         assert proc.stdout  # type narrowing
         while exit_code is None:

--- a/src/algokit/core/tasks/analyze.py
+++ b/src/algokit/core/tasks/analyze.py
@@ -65,7 +65,7 @@ def load_tealer_report(file_path: str) -> TealerAnalysisReport:
     Returns:
         TealerAnalysisReport: Parsed tealer analysis report.
     """
-    with Path(file_path).open() as file:
+    with Path(file_path).open(encoding="utf-8") as file:
         data = json.load(file)
     return TealerAnalysisReport(**data)
 

--- a/src/algokit/core/tasks/mint/models.py
+++ b/src/algokit/core/tasks/mint/models.py
@@ -65,7 +65,7 @@ class TokenMetadata:
     def to_file_path(self) -> Path:
         file_path = Path(tempfile.mkstemp()[1])
         try:
-            with file_path.open("w") as file:
+            with file_path.open(mode="w", encoding="utf-8") as file:
                 file.write(self.to_json(None))
             return file_path
         except FileNotFoundError as err:
@@ -79,7 +79,7 @@ class TokenMetadata:
             return cls(name=name, decimals=decimals)
 
         try:
-            with file_path.open() as file:
+            with file_path.open(encoding="utf-8") as file:
                 data = json.load(file)
                 data["name"] = name
                 data["decimals"] = decimals

--- a/tests/init/test_init.py
+++ b/tests/init/test_init.py
@@ -1097,7 +1097,7 @@ def test_append_to_workspace_path_normalization(
     # Arrange
     tmp_path = tmp_path_factory.mktemp("workspace")
     workspace_file = tmp_path / "test.code-workspace"
-    with workspace_file.open("w") as f:
+    with workspace_file.open(mode="w", encoding="utf-8") as f:
         json.dump(initial_workspace, f)
 
     project_path_obj = tmp_path / project_path
@@ -1107,7 +1107,7 @@ def test_append_to_workspace_path_normalization(
     append_project_to_vscode_workspace(project_path_obj, workspace_file)
 
     # Assert
-    with workspace_file.open("r") as f:
+    with workspace_file.open(mode="r", encoding="utf-8") as f:
         actual_workspace = json.load(f)
 
     assert actual_workspace == expected_workspace

--- a/tests/project/link/test_link.test_link_command_all_success.approved.txt
+++ b/tests/project/link/test_link.test_link_command_all_success.approved.txt
@@ -1,4 +1,4 @@
-✅ 1/4: Finished processing contract_project_2
-✅ 2/4: Finished processing contract_project_3
-✅ 3/4: Finished processing contract_project_4
-✅ 4/4: Finished processing contract_project_5
+1/4: Finished processing contract_project_2
+2/4: Finished processing contract_project_3
+3/4: Finished processing contract_project_4
+4/4: Finished processing contract_project_5

--- a/tests/project/link/test_link.test_link_command_by_name_success.approved.txt
+++ b/tests/project/link/test_link.test_link_command_by_name_success.approved.txt
@@ -1,1 +1,1 @@
-✅ 1/1: Finished processing contract_project_3
+1/1: Finished processing contract_project_3

--- a/tests/project/link/test_link.test_link_command_multiple_names_no_specs_success.approved.txt
+++ b/tests/project/link/test_link.test_link_command_multiple_names_no_specs_success.approved.txt
@@ -1,4 +1,4 @@
 WARNING: No application.json | *.arc32.json | *.arc56.json files found in <cwd>/projects/project3. Skipping...
-✅ 1/2: Finished processing contract_project_3
+1/2: Finished processing contract_project_3
 WARNING: No application.json | *.arc32.json | *.arc56.json files found in <cwd>/projects/project5. Skipping...
-✅ 2/2: Finished processing contract_project_5
+2/2: Finished processing contract_project_5

--- a/tests/project/link/test_link.test_link_command_multiple_names_success.approved.txt
+++ b/tests/project/link/test_link.test_link_command_multiple_names_success.approved.txt
@@ -1,2 +1,2 @@
-✅ 1/2: Finished processing contract_project_3
-✅ 2/2: Finished processing contract_project_5
+1/2: Finished processing contract_project_3
+2/2: Finished processing contract_project_5


### PR DESCRIPTION
Fixes https://github.com/algorandfoundation/algokit-client-generator-ts/issues/154
By forcing the `Popen` used in `run` to use utf-8 encoding we can bypass Windows using the default cp1252 encoding, which causes strange issues.

Additionally I have update a few other places to force utf-8 encoding.

After merging (before release), I'll do some additional smoke tests of the various code paths.