### PR TITLE
fix: handle non zero exit code when running npm ls

### DIFF
--- a/src/algokit/core/compilers/typescript.py
+++ b/src/algokit/core/compilers/typescript.py
@@ -15,8 +15,10 @@ def _find_project_puyats_command(
     Try to find PuyaTs command installed at the project level.
     """
     try:
-        result = run([*npm_command, "ls"])
-        if result.exit_code == 0:
+        result = run([*npm_command, "ls", "--no-unicode"])
+        # Normally we would check the exit code, however `npm ls` may return a non zero exit code
+        # when certain dependencies are not met. We still want to continue processing.
+        if result.output != "":
             compile_command = [*npx_command, PUYATS_NPM_PACKAGE]
             for line in result.output.splitlines():
                 if PUYATS_NPM_PACKAGE in line:

--- a/src/algokit/core/typed_client_generation.py
+++ b/src/algokit/core/typed_client_generation.py
@@ -277,8 +277,10 @@ class TypeScriptClientGenerator(ClientGenerator, language="typescript", extensio
         self, npm_command: list[str], npx_command: list[str], version: str | None
     ) -> list[str] | None:
         try:
-            result = proc.run([*npm_command, "ls"])
-            if result.exit_code == 0:
+            result = proc.run([*npm_command, "ls", "--no-unicode"])
+            # Normally we would check the exit code, however `npm ls` may return a non zero exit code
+            # when certain dependencies are not met. We still want to continue processing.
+            if result.output != "":
                 generate_command = [*npx_command, TYPESCRIPT_NPM_PACKAGE]
                 for line in result.output.splitlines():
                     if TYPESCRIPT_NPM_PACKAGE in line:

--- a/tests/compile/test_typescript.test_compile_py_help.approved.txt
+++ b/tests/compile/test_typescript.test_compile_py_help.approved.txt
@@ -1,7 +1,7 @@
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Running 'npx -y @algorandfoundation/puya-ts -h' in '{current_working_directory}'

--- a/tests/compile/test_typescript.test_puyats_is_installed_globally.approved.txt
+++ b/tests/compile/test_typescript.test_puyats_is_installed_globally.approved.txt
@@ -1,7 +1,7 @@
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: └── @algorandfoundation/puya-ts@1.0.0
 DEBUG: Running 'npx @algorandfoundation/puya-ts --version' in '{current_working_directory}'
 DEBUG: npx: puya-ts 1.0.0

--- a/tests/compile/test_typescript.test_puyats_is_installed_in_project.approved.txt
+++ b/tests/compile/test_typescript.test_puyats_is_installed_in_project.approved.txt
@@ -1,4 +1,4 @@
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: └── @algorandfoundation/puya-ts@1.0.0
 DEBUG: Running 'npx @algorandfoundation/puya-ts --version' in '{current_working_directory}'
 DEBUG: npx: puya-ts 1.0.0

--- a/tests/compile/test_typescript.test_puyats_is_not_installed_anywhere.approved.txt
+++ b/tests/compile/test_typescript.test_puyats_is_not_installed_anywhere.approved.txt
@@ -1,7 +1,7 @@
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Running 'npx -y @algorandfoundation/puya-ts {current_working_directory}/tests/compile/dummy_contract.py' in '{current_working_directory}'

--- a/tests/compile/test_typescript.test_specificed_puyats_version_is_not_installed.approved.txt
+++ b/tests/compile/test_typescript.test_specificed_puyats_version_is_not_installed.approved.txt
@@ -1,6 +1,6 @@
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: └── @algorandfoundation/puya-ts@1.0.0
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: └── @algorandfoundation/puya-ts@1.0.0
 DEBUG: Running 'npx -y @algorandfoundation/puya-ts@1.1.0 {current_working_directory}/tests/compile/dummy_contract.py' in '{current_working_directory}'
 DEBUG: npx: Compilation successful

--- a/tests/generate/test_generate_client.test_generate_client_typescript[linux---output {contract_name}.ts-HelloWorldApp.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[linux---output {contract_name}.ts-HelloWorldApp.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[linux--l typescript -v 2.6.0-HelloWorldAppClient.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[linux--l typescript -v 2.6.0-HelloWorldAppClient.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[linux--l typescript-HelloWorldAppClient.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[linux--l typescript-HelloWorldAppClient.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.py --language typescript-client.py].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.py --language typescript-client.py].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.ts --language typescript --version 3.0.0-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.ts --language typescript --version 3.0.0-client.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.ts-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.ts-client.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[macOS---output {contract_name}.ts-HelloWorldApp.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[macOS---output {contract_name}.ts-HelloWorldApp.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[macOS--l typescript -v 2.6.0-HelloWorldAppClient.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[macOS--l typescript -v 2.6.0-HelloWorldAppClient.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[macOS--l typescript-HelloWorldAppClient.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[macOS--l typescript-HelloWorldAppClient.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.py --language typescript-client.py].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.py --language typescript-client.py].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.ts --language typescript --version 3.0.0-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.ts --language typescript --version 3.0.0-client.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.ts-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.ts-client.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[windows---output {contract_name}.ts-HelloWorldApp.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[windows---output {contract_name}.ts-HelloWorldApp.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[windows--l typescript -v 2.6.0-HelloWorldAppClient.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[windows--l typescript -v 2.6.0-HelloWorldAppClient.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[windows--l typescript-HelloWorldAppClient.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[windows--l typescript-HelloWorldAppClient.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.py --language typescript-client.py].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.py --language typescript-client.py].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.ts --language typescript --version 3.0.0-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.ts --language typescript --version 3.0.0-client.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.ts-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.ts-client.ts].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_npx_failed[linux].approved.txt
+++ b/tests/generate/test_generate_client.test_npx_failed[linux].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_npx_failed[macOS].approved.txt
+++ b/tests/generate/test_generate_client.test_npx_failed[macOS].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_npx_failed[windows].approved.txt
+++ b/tests/generate/test_generate_client.test_npx_failed[windows].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: No matching installed client generator found, run client generator via npx

--- a/tests/generate/test_generate_client.test_typescript_generator_is_installed_globally[linux].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_is_installed_globally[linux].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/.nvm/versions/node/v20.11.0/lib
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_is_installed_globally[macOS].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_is_installed_globally[macOS].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: STDOUT
 DEBUG: npm: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/.nvm/versions/node/v20.11.0/lib
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_is_installed_globally[windows].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_is_installed_globally[windows].approved.txt
@@ -1,9 +1,9 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: STDOUT
 DEBUG: npm.cmd: STDERR
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: /Users/user/.nvm/versions/node/v20.11.0/lib
 DEBUG: npm.cmd: ├── test@1.2.3
 DEBUG: npm.cmd: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_is_installed_in_project[linux].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_is_installed_in_project[linux].approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/my-project
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_is_installed_in_project[macOS].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_is_installed_in_project[macOS].approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/my-project
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_is_installed_in_project[windows].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_is_installed_in_project[windows].approved.txt
@@ -1,5 +1,5 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: /Users/user/my-project
 DEBUG: npm.cmd: ├── test@1.2.3
 DEBUG: npm.cmd: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_version_is_not_installed_anywhere[linux].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_version_is_not_installed_anywhere[linux].approved.txt
@@ -1,10 +1,10 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/my-project
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/.nvm/versions/node/v20.11.0/lib
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_version_is_not_installed_anywhere[macOS].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_version_is_not_installed_anywhere[macOS].approved.txt
@@ -1,10 +1,10 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm ls' in '{current_working_directory}'
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/my-project
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm: /Users/user/.nvm/versions/node/v20.11.0/lib
 DEBUG: npm: ├── test@1.2.3
 DEBUG: npm: └── @algorandfoundation/algokit-client-generator@1.1.2

--- a/tests/generate/test_generate_client.test_typescript_generator_version_is_not_installed_anywhere[windows].approved.txt
+++ b/tests/generate/test_generate_client.test_typescript_generator_version_is_not_installed_anywhere[windows].approved.txt
@@ -1,10 +1,10 @@
 DEBUG: Searching for project installed client generator
-DEBUG: Running 'npm.cmd ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: /Users/user/my-project
 DEBUG: npm.cmd: ├── test@1.2.3
 DEBUG: npm.cmd: └── @algorandfoundation/algokit-client-generator@1.1.2
 DEBUG: Searching for globally installed client generator
-DEBUG: Running 'npm.cmd --global ls' in '{current_working_directory}'
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
 DEBUG: npm.cmd: /Users/user/.nvm/versions/node/v20.11.0/lib
 DEBUG: npm.cmd: ├── test@1.2.3
 DEBUG: npm.cmd: └── @algorandfoundation/algokit-client-generator@1.1.2


### PR DESCRIPTION
Fixes #621

When `npm ls` returns a non zero exit code, we don't parse the result.
We can be more relaxed with the parsing.

This PR will still parse the result, even if an error is returned.
Additionally we only output ASCII chars which is good for windows.