### PR TITLE
fix: compile ts hangs when puya-ts is detected but not installed in the project

### DIFF
--- a/src/algokit/core/compilers/typescript.py
+++ b/src/algokit/core/compilers/typescript.py
@@ -22,6 +22,10 @@ def _find_project_puyats_command(
             compile_command = [*npx_command, PUYATS_NPM_PACKAGE]
             for line in result.output.splitlines():
                 if PUYATS_NPM_PACKAGE in line:
+                    if "UNMET DEPENDENCY" in line:
+                        raise ModuleNotFoundError(
+                            f"{PUYATS_NPM_PACKAGE} was detected in the project, but is not installed."
+                        )
                     if version is not None:
                         installed_version = extract_semantic_version(line)
                         if version == installed_version:

--- a/src/algokit/core/typed_client_generation.py
+++ b/src/algokit/core/typed_client_generation.py
@@ -284,6 +284,10 @@ class TypeScriptClientGenerator(ClientGenerator, language="typescript", extensio
                 generate_command = [*npx_command, TYPESCRIPT_NPM_PACKAGE]
                 for line in result.output.splitlines():
                     if TYPESCRIPT_NPM_PACKAGE in line:
+                        if "UNMET DEPENDENCY" in line:
+                            raise ModuleNotFoundError(
+                                f"{TYPESCRIPT_NPM_PACKAGE} was detected in the project, but is not installed."
+                            )
                         if version is not None:
                             installed_version = extract_semantic_version(line)
                             if extract_semantic_version(version) == installed_version:


### PR DESCRIPTION
When running `algokit compile ts ...` on a project where you have `puya-ts` in the package.json, however it's not actually installed, we incorrectly assume that it's installed and run npx causing the command to hang.

In this scenario you must first install (or bootstrap) the packages, and should throw instead.