### PR TITLE
fix: add fallback for browser opening in explore command

### DIFF
--- a/src/algokit/cli/explore.py
+++ b/src/algokit/cli/explore.py
@@ -114,4 +114,12 @@ def explore_command(network: str) -> None:
         except Exception as e:
             logger.warning(warning, exc_info=e)
     else:
-        click.launch(url)
+        try:
+            click.launch(url)
+        except Exception:
+            # https://github.com/pallets/click/issues/2868
+            try:
+                if not webbrowser.open(url):
+                    logger.warning(f"Failed to open browser. Please open this URL manually: {url}")
+            except Exception:
+                logger.warning(f"Failed to open browser. Please open this URL manually: {url}")

--- a/tests/explore/test_explore.py
+++ b/tests/explore/test_explore.py
@@ -31,3 +31,16 @@ def test_explore_wsl_exception(mocker: MockerFixture, caplog: pytest.LogCaptureF
 
     assert result.exit_code == 0
     assert any("Unable to open browser from WSL" in message for message in caplog.messages)
+
+
+def test_explore_webbrowser_exception(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+    command = "localnet"
+    mocker.patch("algokit.cli.explore.is_wsl", return_value=False)
+    mocker.patch("click.launch", side_effect=Exception("Click Exception"))
+    mocker.patch("webbrowser.open", side_effect=Exception("Webbrowser Exception"))
+
+    with caplog.at_level(logging.WARNING):
+        result = invoke(f"explore {command}")
+
+    assert result.exit_code == 0
+    assert any("Failed to open browser. Please open this URL manually:" in message for message in caplog.messages)


### PR DESCRIPTION
Fixes #638 

Adds error handling around click.launch() with a fallback to webbrowser.open(). 

Fixes issue described in pallets/click#2868


