### PR TITLE
fix: adds health check for indexer

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2647,19 +2647,19 @@ md = ["cmarkgfm (>=0.8.0)"]
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
+    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<3"
 

--- a/tests/goal/test_goal.py
+++ b/tests/goal/test_goal.py
@@ -5,6 +5,7 @@ from subprocess import CompletedProcess
 import pytest
 from algokit.core.sandbox import (
     ALGOD_HEALTH_URL,
+    INDEXER_HEALTH_URL,
     get_algod_network_template,
     get_config_json,
     get_docker_compose_yml,
@@ -28,6 +29,7 @@ def _normalize_output(output: str) -> str:
 @pytest.fixture()
 def _health_success(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url=ALGOD_HEALTH_URL)
+    httpx_mock.add_response(url=INDEXER_HEALTH_URL)
 
 
 @pytest.fixture()

--- a/tests/goal/test_goal.test_goal_console_algod_not_created.approved.txt
+++ b/tests/goal/test_goal.test_goal_console_algod_not_created.approved.txt
@@ -13,6 +13,8 @@ DEBUG: Running '{container_engine} compose up --detach --quiet-pull --wait' in '
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.
 Opening Bash console on the algod node; execute `exit` to return to original console
 DEBUG: Running '{container_engine} exec -it -w /root algokit_sandbox_algod bash' in '{current_working_directory}'

--- a/tests/localnet/conftest.py
+++ b/tests/localnet/conftest.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from algokit.core.sandbox import ALGOD_HEALTH_URL, ALGORAND_IMAGE, INDEXER_IMAGE
+from algokit.core.sandbox import ALGOD_HEALTH_URL, ALGORAND_IMAGE, INDEXER_HEALTH_URL, INDEXER_IMAGE
 from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
 
@@ -12,12 +12,14 @@ from tests.utils.proc_mock import ProcMock
 @pytest.fixture(autouse=True)
 def _algod_health_fast_timings(mocker: MockerFixture) -> None:
     mocker.patch("algokit.core.sandbox.DEFAULT_WAIT_FOR_ALGOD", 0.1)
+    mocker.patch("algokit.core.sandbox.DEFAULT_WAIT_FOR_INDEXER", 0.1)
     mocker.patch("algokit.core.sandbox.DEFAULT_HEALTH_TIMEOUT", 0.1)
 
 
 @pytest.fixture()
 def _health_success(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url=ALGOD_HEALTH_URL)
+    httpx_mock.add_response(url=INDEXER_HEALTH_URL)
 
 
 @pytest.fixture()

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_out_of_date_config.approved.txt
@@ -23,6 +23,8 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.
 
 {app_config}/sandbox/docker-compose.yml

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config.approved.txt
@@ -22,4 +22,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config_with_pull.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_existing_sandbox_with_up_to_date_config_with_pull.approved.txt
@@ -20,4 +20,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_with_named_sandbox_config.approved.txt
@@ -16,4 +16,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.

--- a/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
+++ b/tests/localnet/test_localnet_reset.test_localnet_reset_without_existing_sandbox.approved.txt
@@ -14,6 +14,8 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.
 ----
 {app_config}/sandbox/docker-compose.yml:

--- a/tests/localnet/test_localnet_start.test_localnet_img_check_cmd_error.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_img_check_cmd_error.approved.txt
@@ -20,4 +20,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.

--- a/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start.approved.txt
@@ -20,6 +20,8 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.
 ----
 {app_config}/sandbox/docker-compose.yml:

--- a/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_health_failure.approved.txt
@@ -18,7 +18,7 @@ DEBUG: Running 'docker compose up --detach --quiet-pull --wait' in '{app_config}
 docker: STDOUT
 docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
-DEBUG: AlgoKit LocalNet health request failed
+DEBUG: AlgoKit LocalNet health request failed for algod
 WARNING: AlgoKit LocalNet failed to return a successful health check
 ----
 {app_config}/sandbox/docker-compose.yml:

--- a/tests/localnet/test_localnet_start.test_localnet_start_out_date.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_out_date.approved.txt
@@ -22,4 +22,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.

--- a/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition.approved.txt
@@ -19,6 +19,8 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.
 
 {app_config}/sandbox/docker-compose.yml

--- a/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition_and_missing_config.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_out_of_date_definition_and_missing_config.approved.txt
@@ -19,6 +19,8 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.
 
 {app_config}/sandbox/docker-compose.yml

--- a/tests/localnet/test_localnet_start.test_localnet_start_up_to_date_definition.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_up_to_date_definition.approved.txt
@@ -19,4 +19,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_gitpod_docker_compose_version.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_gitpod_docker_compose_version.approved.txt
@@ -20,4 +20,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_name.approved.txt
@@ -23,6 +23,8 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.
 ----
 {app_config}/sandbox_test/docker-compose.yml:

--- a/tests/localnet/test_localnet_start.test_localnet_start_with_unparseable_docker_compose_version.approved.txt
+++ b/tests/localnet/test_localnet_start.test_localnet_start_with_unparseable_docker_compose_version.approved.txt
@@ -23,4 +23,6 @@ docker: STDERR
 DEBUG: AlgoKit LocalNet started, waiting for health check
 HTTP Request: GET http://localhost:4001/v2/status "HTTP/1.1 200 OK"
 DEBUG: AlgoKit LocalNet health check successful, algod is ready
+HTTP Request: GET http://localhost:8980/health "HTTP/1.1 200 OK"
+DEBUG: AlgoKit LocalNet health check successful, indexer is ready
 Started; execute `algokit explore` to explore LocalNet in a web user interface.


### PR DESCRIPTION
Minor patch that adds an extra health check for the indexer service to ensure it is ready before proceeding. Previously it was only checking algod and would occasionally fail in ci cd when someone is trying to access indexer endpoints right after localnet start because there were no guarantee that indexer is ready (as only algod was being checked for healthy state)
