### PR TITLE
fix: update the brew cask to not require sudo on install

### DIFF
--- a/scripts/update-brew-cask.sh
+++ b/scripts/update-brew-cask.sh
@@ -103,12 +103,6 @@ cask "$package_name" do
   homepage "$homepage"
 
   binary "#{staged_path}/#{token}"
-
-  postflight do
-    set_permissions "#{staged_path}/#{token}", "0755"
-  end
-
-  uninstall delete: "/usr/local/bin/#{token}"
 end
 EOF
 


### PR DESCRIPTION
This removes the required prompt elevation on install, update or uninstall.
I have tested locally (on a fresh MacOS VM) by installing the updated version of the cask and both install and uninstall works correctly.

~I plan to also update to cask directly in the tap and do another test to confirm before merging this PR.~ Done