### PR TITLE
chore: support passing client generator args to the language

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -70,6 +70,7 @@
     - [-v, --version ](#-v---version--1)
     - [Arguments](#arguments-7)
     - [APP_SPEC_PATH_OR_DIR](#app_spec_path_or_dir)
+    - [ARGS](#args)
   - [goal](#goal)
     - [Options](#options-11)
     - [--console](#--console)
@@ -588,7 +589,7 @@ Supply the path to an application specification file or a directory to recursive
 for "application.json" files
 
 ```shell
-algokit generate client [OPTIONS] APP_SPEC_PATH_OR_DIR
+algokit generate client [OPTIONS] [APP_SPEC_PATH_OR_DIR] [ARGS]...
 ```
 
 ### Options
@@ -615,7 +616,11 @@ The client generator version to pin to, for example, 1.0.0. If no version is spe
 
 
 ### APP_SPEC_PATH_OR_DIR
-Required argument
+Optional argument
+
+
+### ARGS
+Optional argument(s)
 
 ## goal
 

--- a/src/algokit/cli/project/link.py
+++ b/src/algokit/cli/project/link.py
@@ -90,6 +90,7 @@ def _link_projects(
         generator.generate_all(
             contract_project_root,
             output_path_pattern,
+            None,  # no additional args for project link
             raise_on_path_resolution_failure=fail_fast,
         )
     except AppSpecsNotFoundError:

--- a/tests/generate/test_generate_client.py
+++ b/tests/generate/test_generate_client.py
@@ -112,6 +112,7 @@ def test_generate_no_options(application_json: Path) -> None:
         ("-o client.ts --language python", "client.ts"),
         ("-o client.py --language python --version 1.1.2", "client.py"),
         ("-l python -v 1.1.0", "hello_world_app_client.py"),
+        ("-o client.py -p --mode minimal", "client.py"),
     ],
 )
 def test_generate_client_python(
@@ -124,7 +125,7 @@ def test_generate_client_python(
     proc_mock.should_bad_exit_on(["poetry", "show", PYTHON_PYPI_PACKAGE, "--tree"])
     proc_mock.should_bad_exit_on(["pipx", "list", "--short"])
 
-    result = invoke(f"generate client {options} {application_json.name}", cwd=application_json.parent)
+    result = invoke(f"generate client {application_json.name} {options}", cwd=application_json.parent)
     assert result.exit_code == 0
     verify(
         _normalize_output(result.output),
@@ -133,9 +134,8 @@ def test_generate_client_python(
     )
     version = options.split()[-1] if "--version" in options or "-v" in options else None
     assert len(proc_mock.called) == 4  # noqa: PLR2004
-    assert (
-        proc_mock.called[3].command
-        == _get_python_generate_command(version, application_json, expected_output_path).split()
+    assert " ".join(proc_mock.called[3].command).startswith(
+        _get_python_generate_command(version, application_json, expected_output_path)
     )
 
 
@@ -278,6 +278,7 @@ def test_generate_client_python_multiple_app_specs_in_directory(
         ("-o client.py --language typescript", "client.py"),
         ("-o client.ts --language typescript --version 3.0.0", "client.ts"),
         ("-l typescript -v 2.6.0", "HelloWorldAppClient.ts"),
+        ("-o client.ts -pn --mode minimal", "client.ts"),
     ],
 )
 def test_generate_client_typescript(
@@ -291,7 +292,7 @@ def test_generate_client_typescript(
     proc_mock.should_bad_exit_on([npm_command, "ls"])
     proc_mock.should_bad_exit_on([npm_command, "ls", "--global"])
 
-    result = invoke(f"generate client {options} {application_json.name}", cwd=application_json.parent)
+    result = invoke(f"generate client {application_json.name} {options}", cwd=application_json.parent)
 
     assert result.exit_code == 0
     verify(
@@ -301,9 +302,8 @@ def test_generate_client_typescript(
     )
     version = options.split()[-1] if "--version" in options or "-v" in options else "latest"
     assert len(proc_mock.called) == 3  # noqa: PLR2004
-    assert (
-        proc_mock.called[2].command
-        == _get_typescript_generate_command(version, application_json, expected_output_path).split()
+    assert " ".join(proc_mock.called[2].command).startswith(
+        _get_typescript_generate_command(version, application_json, expected_output_path)
     )
 
 

--- a/tests/generate/test_generate_client.test_generate_client_python[-o client.py -p --mode minimal-client.py].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_python[-o client.py -p --mode minimal-client.py].approved.txt
@@ -1,0 +1,18 @@
+DEBUG: Searching for project installed client generator
+DEBUG: Running 'poetry show algokit-client-generator --tree' in '{current_working_directory}'
+DEBUG: poetry: STDOUT
+DEBUG: poetry: STDERR
+DEBUG: Running 'pipx --version' in '{current_working_directory}'
+DEBUG: pipx: STDOUT
+DEBUG: pipx: STDERR
+DEBUG: Searching for globally installed client generator
+DEBUG: Running 'pipx list --short' in '{current_working_directory}'
+DEBUG: pipx: STDOUT
+DEBUG: pipx: STDERR
+DEBUG: No matching installed client generator found, run client generator via pipx
+Generating Python client code for application specified in {current_working_directory}/application.json and writing to client.py
+DEBUG: Running 'pipx run --spec=algokit-client-generator algokitgen-py -a {current_working_directory}/application.json -o client.py -p --mode minimal' in '{current_working_directory}'
+DEBUG: pipx: STDOUT
+DEBUG: pipx: STDERR
+STDOUT
+STDERR

--- a/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.ts -pn --mode minimal-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[linux--o client.ts -pn --mode minimal-client.ts].approved.txt
@@ -1,0 +1,15 @@
+DEBUG: Searching for project installed client generator
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
+DEBUG: npm: STDOUT
+DEBUG: npm: STDERR
+DEBUG: Searching for globally installed client generator
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
+DEBUG: npm: STDOUT
+DEBUG: npm: STDERR
+DEBUG: No matching installed client generator found, run client generator via npx
+Generating TypeScript client code for application specified in {current_working_directory}/application.json and writing to client.ts
+DEBUG: Running 'npx --yes @algorandfoundation/algokit-client-generator@latest generate -a {current_working_directory}/application.json -o client.ts -pn --mode minimal' in '{current_working_directory}'
+DEBUG: npx: STDOUT
+DEBUG: npx: STDERR
+STDOUT
+STDERR

--- a/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.ts -pn --mode minimal-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[macOS--o client.ts -pn --mode minimal-client.ts].approved.txt
@@ -1,0 +1,15 @@
+DEBUG: Searching for project installed client generator
+DEBUG: Running 'npm ls --no-unicode' in '{current_working_directory}'
+DEBUG: npm: STDOUT
+DEBUG: npm: STDERR
+DEBUG: Searching for globally installed client generator
+DEBUG: Running 'npm --global ls --no-unicode' in '{current_working_directory}'
+DEBUG: npm: STDOUT
+DEBUG: npm: STDERR
+DEBUG: No matching installed client generator found, run client generator via npx
+Generating TypeScript client code for application specified in {current_working_directory}/application.json and writing to client.ts
+DEBUG: Running 'npx --yes @algorandfoundation/algokit-client-generator@latest generate -a {current_working_directory}/application.json -o client.ts -pn --mode minimal' in '{current_working_directory}'
+DEBUG: npx: STDOUT
+DEBUG: npx: STDERR
+STDOUT
+STDERR

--- a/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.ts -pn --mode minimal-client.ts].approved.txt
+++ b/tests/generate/test_generate_client.test_generate_client_typescript[windows--o client.ts -pn --mode minimal-client.ts].approved.txt
@@ -1,0 +1,15 @@
+DEBUG: Searching for project installed client generator
+DEBUG: Running 'npm.cmd ls --no-unicode' in '{current_working_directory}'
+DEBUG: npm.cmd: STDOUT
+DEBUG: npm.cmd: STDERR
+DEBUG: Searching for globally installed client generator
+DEBUG: Running 'npm.cmd --global ls --no-unicode' in '{current_working_directory}'
+DEBUG: npm.cmd: STDOUT
+DEBUG: npm.cmd: STDERR
+DEBUG: No matching installed client generator found, run client generator via npx
+Generating TypeScript client code for application specified in {current_working_directory}/application.json and writing to client.ts
+DEBUG: Running 'npx.cmd --yes @algorandfoundation/algokit-client-generator@latest generate -a {current_working_directory}/application.json -o client.ts -pn --mode minimal' in '{current_working_directory}'
+DEBUG: npx.cmd: STDOUT
+DEBUG: npx.cmd: STDERR
+STDOUT
+STDERR


### PR DESCRIPTION
Extends the CLI to support arbitrary arg passing when running `algokit generate client`, which better supports the mode feature in https://github.com/algorandfoundation/algokit-client-generator-ts/pull/194