### PR TITLE
chore: ensure bootstrap tests only write config to temp dir

### DIFF
--- a/src/algokit/core/config_commands/js_package_manager.py
+++ b/src/algokit/core/config_commands/js_package_manager.py
@@ -1,5 +1,6 @@
 import enum
 import logging
+from pathlib import Path
 
 import click
 import questionary
@@ -7,8 +8,6 @@ import questionary
 from algokit.core.conf import get_app_config_dir
 
 logger = logging.getLogger(__name__)
-
-JS_PACKAGE_MANAGER_CONFIG_FILE = get_app_config_dir() / "default-js-package-manager"
 
 
 class JSPackageManager(str, enum.Enum):
@@ -19,20 +18,26 @@ class JSPackageManager(str, enum.Enum):
         return self.value
 
 
+def _get_js_config_file() -> Path:
+    return get_app_config_dir() / "default-js-package-manager"
+
+
 def get_js_package_manager() -> str | None:
     """Get the default JavaScript package manager for use by AlgoKit CLI.
     None implies it has not been set yet, likely to be first time user.
     """
 
-    if JS_PACKAGE_MANAGER_CONFIG_FILE.exists():
-        return JS_PACKAGE_MANAGER_CONFIG_FILE.read_text().strip()
+    config_file = _get_js_config_file()
+    if config_file.exists():
+        return config_file.read_text().strip()
     return None
 
 
 def save_js_package_manager(manager: str) -> None:
     if manager not in JSPackageManager:
         raise ValueError(f"Invalid JavaScript package manager: {manager}")
-    JS_PACKAGE_MANAGER_CONFIG_FILE.write_text(manager)
+    config_file = _get_js_config_file()
+    config_file.write_text(manager)
 
 
 @click.command("js-package-manager", short_help="Configure the default JavaScript package manager for AlgoKit.")

--- a/src/algokit/core/config_commands/py_package_manager.py
+++ b/src/algokit/core/config_commands/py_package_manager.py
@@ -1,5 +1,6 @@
 import enum
 import logging
+from pathlib import Path
 
 import click
 import questionary
@@ -7,8 +8,6 @@ import questionary
 from algokit.core.conf import get_app_config_dir
 
 logger = logging.getLogger(__name__)
-
-PY_PACKAGE_MANAGER_CONFIG_FILE = get_app_config_dir() / "default-py-package-manager"
 
 
 class PyPackageManager(str, enum.Enum):
@@ -19,20 +18,26 @@ class PyPackageManager(str, enum.Enum):
         return self.value
 
 
+def _get_py_config_file() -> Path:
+    return get_app_config_dir() / "default-py-package-manager"
+
+
 def get_py_package_manager() -> str | None:
     """Get the default Python package manager for use by AlgoKit CLI.
     None implies it has not been set yet, likely to be first time user.
     """
 
-    if PY_PACKAGE_MANAGER_CONFIG_FILE.exists():
-        return PY_PACKAGE_MANAGER_CONFIG_FILE.read_text().strip()
+    config_file = _get_py_config_file()
+    if config_file.exists():
+        return config_file.read_text().strip()
     return None
 
 
 def save_py_package_manager(manager: str) -> None:
     if manager not in PyPackageManager:
         raise ValueError(f"Invalid Python package manager: {manager}")
-    PY_PACKAGE_MANAGER_CONFIG_FILE.write_text(manager)
+    config_file = _get_py_config_file()
+    config_file.write_text(manager)
 
 
 @click.command("py-package-manager", short_help="Configure the default Python package manager for AlgoKit.")

--- a/tests/config/test_package_managers.py
+++ b/tests/config/test_package_managers.py
@@ -3,6 +3,8 @@ Essential tests for package manager configuration commands.
 Focuses on critical user-facing functionality only.
 """
 
+import pytest
+
 from tests.utils.approvals import verify
 from tests.utils.click_invoker import invoke
 
@@ -38,6 +40,7 @@ def test_py_package_manager_invalid_argument() -> None:
     verify(result.output)
 
 
+@pytest.mark.usefixtures("app_dir_mock")
 def test_js_package_manager_set_npm() -> None:
     """Test setting npm as js package manager."""
     result = invoke("config js-package-manager npm")
@@ -45,6 +48,7 @@ def test_js_package_manager_set_npm() -> None:
     verify(result.output)
 
 
+@pytest.mark.usefixtures("app_dir_mock")
 def test_js_package_manager_set_pnpm() -> None:
     """Test setting pnpm as js package manager."""
     result = invoke("config js-package-manager pnpm")
@@ -52,6 +56,7 @@ def test_js_package_manager_set_pnpm() -> None:
     verify(result.output)
 
 
+@pytest.mark.usefixtures("app_dir_mock")
 def test_py_package_manager_set_poetry() -> None:
     """Test setting poetry as py package manager."""
     result = invoke("config py-package-manager poetry")
@@ -59,6 +64,7 @@ def test_py_package_manager_set_poetry() -> None:
     verify(result.output)
 
 
+@pytest.mark.usefixtures("app_dir_mock")
 def test_py_package_manager_set_uv() -> None:
     """Test setting uv as py package manager."""
     result = invoke("config py-package-manager uv")

--- a/tests/utils/app_dir_mock.py
+++ b/tests/utils/app_dir_mock.py
@@ -14,6 +14,8 @@ def tmp_app_dir(mocker: MockerFixture, tmp_path: Path) -> AppDirs:
     app_config_dir = tmp_path / "config"
     app_config_dir.mkdir()
     mocker.patch("algokit.core.sandbox.get_app_config_dir").return_value = app_config_dir
+    mocker.patch("algokit.core.config_commands.js_package_manager.get_app_config_dir").return_value = app_config_dir
+    mocker.patch("algokit.core.config_commands.py_package_manager.get_app_config_dir").return_value = app_config_dir
 
     app_state_dir = tmp_path / "state"
     app_state_dir.mkdir()


### PR DESCRIPTION
Previously the tests would write to the user config dir, which meant it would impact bootstrap behaviour on the machine the test was run on.