### PR TITLE
ci: fix redundant workflow trigger after production release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,4 +206,4 @@ major_on_zero = true
 upload_to_repository = false
 tag_commit = true
 branch = "main"
-commit_message = "{version}\n\nskip-checks: true"
+commit_message = "{version}\n\n[skip ci]"


### PR DESCRIPTION
## Proposed Changes

Changes semantic-release commit message format from 'skip-checks: true'
to '[skip ci]' to use GitHub Actions' native skip marker. This prevents
the version bump commit from triggering a secondary CD workflow run.

  - https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs

Noticed the bug after seeing a secondary beta release trigger after recent prod release https://github.com/algorandfoundation/algokit-cli/actions/runs/21485628425