### PR TITLE
feat: make python template generator call uv x poetry aware

### DIFF
--- a/src/algokit/cli/init/command.py
+++ b/src/algokit/cli/init/command.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
 from typing import NoReturn
+from algokit.core.config_commands.py_package_manager import PyPackageManager, get_py_package_manager
 
 import click
 import prompt_toolkit.document
@@ -133,7 +134,12 @@ def initialize_new_project(  # noqa: PLR0913, C901, PLR0915
         commit=template_url_ref,
         unsafe_security_accept_template_url=unsafe_security_accept_template_url,
     )
-
+    
+    # Defines the python_package_manager answer for the copier to generate the project based on the user
+    # configuration or default to UV if not set, this is needed for the templates to know which package manager to generate files for
+    selected_py_package_manager = get_py_package_manager() or str(PyPackageManager.UV)
+    answers_dict.setdefault("python_package_manager", selected_py_package_manager)
+    
     for custom_answer in template.answers or []:
         answers_dict.setdefault(*custom_answer)
 

--- a/src/algokit/cli/init/command.py
+++ b/src/algokit/cli/init/command.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
 from typing import NoReturn
-from algokit.core.config_commands.py_package_manager import PyPackageManager, get_py_package_manager
 
 import click
 import prompt_toolkit.document
@@ -18,6 +17,7 @@ from algokit.cli.init.helpers import (
 )
 from algokit.core import proc, questionary_extensions
 from algokit.core.conf import get_algokit_config
+from algokit.core.config_commands.py_package_manager import PyPackageManager, get_py_package_manager
 from algokit.core.init import (
     append_project_to_vscode_workspace,
     get_git_user_info,
@@ -135,10 +135,11 @@ def initialize_new_project(  # noqa: PLR0913, C901, PLR0915
         unsafe_security_accept_template_url=unsafe_security_accept_template_url,
     )
 
-    # Defines the python_package_manager answer for the copier to generate the project based on the user
-    # configuration or default to UV if not set, this is needed for the templates to know which package manager to generate files for
+    # Set python_package_manager for Copier from user config.
+    # Default to UV so templates can render manager-specific files.
     selected_py_package_manager = get_py_package_manager() or str(PyPackageManager.UV)
     answers_dict.setdefault("python_package_manager", selected_py_package_manager)
+
 
     for custom_answer in template.answers or []:
         answers_dict.setdefault(*custom_answer)

--- a/src/algokit/cli/init/command.py
+++ b/src/algokit/cli/init/command.py
@@ -134,12 +134,12 @@ def initialize_new_project(  # noqa: PLR0913, C901, PLR0915
         commit=template_url_ref,
         unsafe_security_accept_template_url=unsafe_security_accept_template_url,
     )
-    
+
     # Defines the python_package_manager answer for the copier to generate the project based on the user
     # configuration or default to UV if not set, this is needed for the templates to know which package manager to generate files for
     selected_py_package_manager = get_py_package_manager() or str(PyPackageManager.UV)
     answers_dict.setdefault("python_package_manager", selected_py_package_manager)
-    
+
     for custom_answer in template.answers or []:
         answers_dict.setdefault(*custom_answer)
 

--- a/tests/init/test_init.py
+++ b/tests/init/test_init.py
@@ -573,6 +573,25 @@ def test_init_template_url_and_ref(tmp_path_factory: TempPathFactory, mocker: Mo
     assert result.exit_code == 0
     assert mock_copier_worker_cls.call_args.kwargs["vcs_ref"] == ref
 
+@pytest.mark.usefixtures("mock_questionary_input")
+def test_init_passes_python_package_manager_from_user_config(
+    tmp_path_factory: TempPathFactory, mocker: MockerFixture
+) -> None:
+    worker_cls = mocker.patch("copier._main.Worker")
+    worker_cls.return_value.__enter__.return_value.template.url_expanded = "URL"
+    mocker.patch("algokit.cli.init.command.get_py_package_manager", return_value="poetry")
+
+    cwd = tmp_path_factory.mktemp("cwd")
+    result = invoke(
+        "init --name myapp --no-git --no-bootstrap "
+        "--template-url gh:algorandfoundation/algokit-python-template "
+        "--UNSAFE-SECURITY-accept-template-url --no-workspace",
+        cwd=cwd,
+    )
+
+    assert result.exit_code == 0
+    assert worker_cls.call_args.kwargs["data"]["python_package_manager"] == "poetry"
+
 
 def test_init_blessed_template_url_get_community_warning(
     tmp_path_factory: TempPathFactory, mock_questionary_input: PipeInput


### PR DESCRIPTION
📝 Add python_package_manager to Template Context
🚀 Why

We're moving to uv as the default, but our templates don't know that yet! This change passes a variable so the template can decide whether to generate a modern uv project or stay on poetry for older versions.

🛠️ What Changed

Context Injection: Added python_package_manager to the answers_dict we send to Copier.

Smart Default: It defaults to uv if nothing else is set.

Test to check if the worker passes the new  python_package_manager to the provider

The "Handshake": Now templates can just use {% if python_package_manager == 'uv' %} to switch their logic.