### PR TITLE
Bump pyjwt and requests to resolve pip-audit CVEs

### DIFF
--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -24,7 +24,8 @@ jobs:
         run: |
           set -o pipefail
           uv export --no-dev --no-group docs --no-emit-project -o requirements.txt
-          uv run pip-audit -r requirements.txt
+          # CVE-2026-4539: low-severity ReDoS in pygments (transitive dep), no fix available as of 2026-03-27
+          uv run pip-audit -r requirements.txt --ignore-vuln CVE-2026-4539
 
       - name: Check formatting with Ruff
         run: uv run ruff format --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ dependencies = [
     # pyjwt is locked because it's explicitly vendored from auth0 repo,
     # to reduce dependency on auth0 package that caused many adhoc transitive dependency errors.
     # See header in src/algokit/core/_vendor/auth0/authentication/token_verifier.py
-    "pyjwt>=2.10.1,<3.0.0",
+    "pyjwt>=2.12.0,<3.0.0",
     "cryptography>=46.0.5,<47.0.0",  # pyjwt weak dependency, explicitly required in vendored file
     "algokit-utils>=5.0.0a7,<6.0.0",
     "multiformats==0.3.1",
     "multiformats-config==0.3.1",  # pinned in lockstep with multiformats
     "jsondiff>=2.0.0,<3.0.0",
-    "requests>=2.31.0,<3.0.0",
+    "requests>=2.33.0,<3.0.0",
     "textual>=3.0.1,<4.0.0",
     "prompt-toolkit==3.0.51",  # dependency of questionary, pinned to avoid 3.0.52 breaking changes
     "pywin32>=311,<312; sys_platform == 'win32'",  # transitive dep of pyclip, pinned for Python 3.14 on Windows

--- a/uv.lock
+++ b/uv.lock
@@ -77,11 +77,11 @@ requires-dist = [
     { name = "multiformats-config", specifier = "==0.3.1" },
     { name = "prompt-toolkit", specifier = "==3.0.51" },
     { name = "pyclip", specifier = ">=0.7.0,<0.8.0" },
-    { name = "pyjwt", specifier = ">=2.10.1,<3.0.0" },
+    { name = "pyjwt", specifier = ">=2.12.0,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=311,<312" },
     { name = "questionary", specifier = ">=1.10.0,<2.0.0" },
-    { name = "requests", specifier = ">=2.31.0,<3.0.0" },
+    { name = "requests", specifier = ">=2.33.0,<3.0.0" },
     { name = "shellingham", specifier = ">=1.5.4,<2.0.0" },
     { name = "textual", specifier = ">=3.0.1,<4.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1,<3.0.0" },
@@ -1974,11 +1974,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
@@ -2297,7 +2300,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2305,9 +2308,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `pyjwt` from `>=2.10.1` to `>=2.12.0` to fix CVE-2026-32597
- Bump `requests` from `>=2.31.0` to `>=2.33.0` to fix CVE-2026-25645
- Ignore CVE-2026-4539 in CI (low: ReDoS in pygments transitive dep, no fix available yet)

## Test plan
- [x] Verify `pip-audit` passes in CI
- [x] Verify `tests/dispenser/test_dispenser.py` passes (covers pyjwt 2.12.x and requests 2.33.0 usage via vendored auth0 token verifier)