### PR TITLE
fix: resolve silent failures in 'algokit project deploy' by improving error logging

### DIFF
--- a/src/algokit/cli/project/deploy.py
+++ b/src/algokit/cli/project/deploy.py
@@ -129,6 +129,8 @@ def _execute_deploy_command(  # noqa: PLR0913
         ) from ex
     else:
         if result.exit_code != 0:
+            header = " deploy command output: ".center(80, "·")
+            logger.error(f"\n{header}\n{result.output}")
             raise click.ClickException(f"Deployment command exited with error code = {result.exit_code}")
 
 

--- a/src/algokit/core/proc.py
+++ b/src/algokit/core/proc.py
@@ -49,6 +49,7 @@ def run(  # noqa: PLR0913
         env=env,
         bufsize=1,  # line buffering, works because text=True
         encoding="utf-8",
+        errors="backslashreplace",
     ) as proc:
         assert proc.stdout  # type narrowing
         while exit_code is None:


### PR DESCRIPTION
## Description
This PR resolves an issue where `algokit project deploy` would fail silently when errors occurred in the deployment configuration (e.g., an `ImportError` in `deploy_config.py`). 

The silent failure was primarily caused by two factors:
1. **Encoding Sensitivity**: Subprocess output containing non-UTF-8 characters could cause the output reader to crash, silencing the error.
2. **Missing Error Fallback**: The `deploy` command lacked an explicit fallback to display captured subprocess output when a failure occurred, relying solely on real-time logging which could be suppressed or interrupted.

## Changes
- **`src/algokit/core/proc.py`**: Added `errors="backslashreplace"` to `proc.run` to ensure that decoding errors in subprocess output are handled gracefully rather than crashing the CLI.
- **`src/algokit/cli/project/deploy.py`**: Added explicit logging of the captured subprocess output (at the `ERROR` level) whenever the deployment command exits with a non-zero code. This aligns the behavior with the `project run` command.

## Verification
Verified using a reproduction script that triggers an `ImportError` and produces non-UTF-8 output. The CLI now correctly displays the Python traceback and error context even if real-time logging is insufficient.
## Related Issues
Closes #710