### PR TITLE
fix: show deploy command output on failure

### DIFF
--- a/src/algokit/cli/project/deploy.py
+++ b/src/algokit/cli/project/deploy.py
@@ -129,7 +129,10 @@ def _execute_deploy_command(  # noqa: PLR0913
         ) from ex
     else:
         if result.exit_code != 0:
-            raise click.ClickException(f"Deployment command exited with error code = {result.exit_code}")
+            error_message = f"Deployment command exited with error code = {result.exit_code}"
+            if result.output.strip():
+                error_message += f"\n\nDeploy command output:\n{result.output.strip()}"
+            raise click.ClickException(error_message)
 
 
 class _CommandParamType(click.types.StringParamType):

--- a/tests/project/deploy/test_deploy.test_command_bad_exit_code.approved.txt
+++ b/tests/project/deploy/test_deploy.test_command_bad_exit_code.approved.txt
@@ -13,3 +13,6 @@ Deploying smart contracts from AlgoKit compliant repository 🚀
 DEBUG: Running '/bin/gm' in '{current_working_directory}'
 /bin/gm: it is not morning
 Error: Deployment command exited with error code = -1
+
+Deploy command output:
+it is not morning


### PR DESCRIPTION
## Summary
- include captured deploy subprocess output in the ClickException when `algokit project deploy` exits non-zero
- update the existing bad-exit deploy approval snapshot so silent deploy failures stay covered

## Verification
- `CI=1 .venv/bin/python -m pytest tests/project/deploy/test_deploy.py::test_command_bad_exit_code`
- `.venv/bin/ruff check src/algokit/cli/project/deploy.py tests/project/deploy/test_deploy.py`

Closes #710

DevLoot bounty: https://devloot.xyz/bounty/1
Algorand payout address: `R7NHEHQY6DZJM74L442ML3REU66F7XFZ6FVHGUH4MI7FXPPLMMRFUJBHEM`