### PR TITLE
fix: include deploy command output on failure

### DIFF
--- a/src/algokit/cli/project/deploy.py
+++ b/src/algokit/cli/project/deploy.py
@@ -17,6 +17,14 @@ from algokit.core.utils import resolve_command_path, split_command_string
 logger = logging.getLogger(__name__)
 
 
+def _format_deploy_error(result: proc.RunResult) -> str:
+    msg = f"Deployment command exited with error code = {result.exit_code}"
+    command_output = result.output.strip()
+    if command_output:
+        msg = f"{msg}\n\nCommand output:\n{command_output}"
+    return msg
+
+
 def _ensure_aliases(
     config_env: dict[str, str],
     deployer_alias: str | None = None,
@@ -129,7 +137,7 @@ def _execute_deploy_command(  # noqa: PLR0913
         ) from ex
     else:
         if result.exit_code != 0:
-            raise click.ClickException(f"Deployment command exited with error code = {result.exit_code}")
+            raise click.ClickException(_format_deploy_error(result))
 
 
 class _CommandParamType(click.types.StringParamType):

--- a/tests/project/deploy/test_deploy.test_command_bad_exit_code.approved.txt
+++ b/tests/project/deploy/test_deploy.test_command_bad_exit_code.approved.txt
@@ -13,3 +13,6 @@ Deploying smart contracts from AlgoKit compliant repository 🚀
 DEBUG: Running '/bin/gm' in '{current_working_directory}'
 /bin/gm: it is not morning
 Error: Deployment command exited with error code = -1
+
+Command output:
+it is not morning


### PR DESCRIPTION
## Summary
- include captured deploy command output in the ClickException when `algokit project deploy` exits non-zero
- update the bad-exit deploy approval snapshot so silent failures stay covered

## Verification
- `python -m pytest tests/project/deploy/test_deploy.py::test_command_bad_exit_code -q`
- `python -m ruff check src/algokit/cli/project/deploy.py tests/project/deploy/test_deploy.py`

Closes #710

DevLoot bounty: https://devloot.xyz/bounty/1