### PR TITLE
chore: Fix `algokit goal` links

### DIFF
--- a/src/algokit/cli/goal.py
+++ b/src/algokit/cli/goal.py
@@ -39,7 +39,7 @@ def goal_command(*, console: bool, interactive: bool, goal_args: list[str]) -> N
     """
     Run the Algorand goal CLI against the AlgoKit LocalNet.
 
-    Look at https://dev.algorand.co/algokit/algokit-cli/goal for more information.
+    Look at https://dev.algorand.co/algokit/cli/goal for more information.
     """
     goal_args = list(goal_args)
     container_engine = get_container_engine()

--- a/tests/goal/test_goal.test_goal_help.approved.txt
+++ b/tests/goal/test_goal.test_goal_help.approved.txt
@@ -2,7 +2,7 @@ Usage: algokit goal [OPTIONS] [GOAL_ARGS]...
 
   Run the Algorand goal CLI against the AlgoKit LocalNet.
 
-  Look at https://dev.algorand.co/algokit/algokit-cli/goal for more information.
+  Look at https://dev.algorand.co/algokit/cli/goal for more information.
 
 Options:
   --console      Open a Bash console so you can execute multiple goal commands


### PR DESCRIPTION
During a migration we some links changed. This PR fixes them.

Some stuff is still to be fixed, mainly because it should point at the `goal clerk` docs but we don't have them on our devportal.

Remaining errors (for this specific link) on this repo:
```console
$ git grep "https://dev.algorand.co/algokit/algokit-cli/goal"
docs/src/content/docs/features/goal.md:AlgoKit goal command provides the user with a mechanism to run [goal cli](https://dev.algorand.co/algokit/algokit-cli/goal/) commands against the current [AlgoKit LocalNet](/algokit-cli/features/localnet/).
docs/src/content/docs/features/tasks/send.md:Please note, at the moment this feature only supports [`goal clerk`](https://dev.algorand.co/algokit/algokit-cli/goal/) compatible transaction objects.
docs/src/content/docs/features/tasks/sign.md:Please note, at the moment this feature only supports [`goal clerk`](https://dev.algorand.co/algokit/algokit-cli/goal/) compatible transaction objects.
```